### PR TITLE
tree: complete the rename to fedora-coreos-koji-tagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /work
 RUN sed -e "s/[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}/$(uuidgen)/g" /etc/fedora-messaging/fedora.toml > /work/my_config.toml
 
 # Set the Application Name
-RUN sed -i 's|Example Application|CoreOS Koji Tagger: https://pagure.io/dusty/coreos-koji-tagger|' /work/my_config.toml
+RUN sed -i 's|Example Application|Fedora CoreOS Koji Tagger: https://github.com/coreos/fedora-coreos-koji-tagger|' /work/my_config.toml
 
 # Lower log levels to WARNING level
 RUN sed -i 's/INFO/WARNING/' /work/my_config.toml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# coreos-koji-tagger
+# fedora-coreos-koji-tagger
 
 Source code that monitors a git repo and tags packages over into
 appropriate koji tags to be consumed by Fedora CoreOS build processes.
@@ -8,8 +8,8 @@ appropriate koji tags to be consumed by Fedora CoreOS build processes.
 Create a new project and build the container.
 
 ```
-oc new-project coreos-koji-tagger
-oc new-build --strategy=docker https://pagure.io/dusty/coreos-koji-tagger --to coreos-koji-tagger-img
+oc new-project fedora-coreos-koji-tagger
+oc new-build --strategy=docker https://github.com/coreos/fedora-coreos-koji-tagger --to fedora-coreos-koji-tagger-img
 ```
 
 Use kedge to get up and running in openshift:

--- a/kedge.yaml
+++ b/kedge.yaml
@@ -1,4 +1,4 @@
-name: coreos-koji-tagger
+name: fedora-coreos-koji-tagger
 
 deploymentConfigs:
   - containers:
@@ -11,10 +11,10 @@ deploymentConfigs:
         imageChangeParams:
           automatic: true
           containerNames:
-          - coreos-koji-tagger
+          - fedora-coreos-koji-tagger
           from:
             kind: ImageStreamTag
-            name: coreos-koji-tagger-img:latest
+            name: fedora-coreos-koji-tagger-img:latest
 #secrets:
 #  - name: pagure-token
 #    data:


### PR DESCRIPTION
Just something I noticed while perusing the codebase.