### PR TITLE
coreos-koji-tagger: add target release heuristic for fedora-coreos-pi…

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -351,6 +351,10 @@ def get_releasever_from_buildroottag(buildroottag: str) -> str:
         # example: module-zincati-rolling-3020190711144249-a23e773d-build
         releasever = re.search('module-zincati-rolling-(\d\d)',
                                                 buildroottag).group(1)
+    elif 'fedora-coreos-pinger' in buildroottag:
+        # example: module-fedora-coreos-pinger-rolling-3020190720131029-a23e773d-build
+        releasever = re.search('module-fedora-coreos-pinger-rolling-(\d\d)',
+                                                buildroottag).group(1)
     else:
         # example: f30-build
         releasever = re.search('f(\d\d)', buildroottag).group(1)


### PR DESCRIPTION
…nger

Like `zincati` this is built as a module - use a similar heuristic.

---

This has not been tested, however this package is built in a similar way to `zincati` and should work with the same conditions.