### PR TITLE
coreos-koji-tagger: move to koji python library

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -10,6 +10,12 @@ RUN dnf update -y && dnf clean all
 # Install pagure/fedmsg libraries
 RUN dnf -y install dnf-plugins-core python3-libpagure fedora-messaging koji krb5-workstation && dnf clean all
 
+# Update koji src to 1.18 for multicall support (not yet packaged as an RPM)
+RUN dnf -y install git && dnf clean all
+RUN rm -rf /usr/lib/python3.7/site-packages/koji
+RUN git -C /opt/ clone -b koji-1.18.0 https://pagure.io/koji.git
+ENV PYTHONPATH=/opt/koji/
+
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by
 # installing the fedora-packager rpm. We don't need the deps because
 # we aren't building anything.

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -16,7 +16,7 @@ import requests
 
 # Set local logging 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 
 # The target and the intermediate tag. The target tag is where we want
 # builds to end up. We'll check the target tag to see if builds are already
@@ -241,8 +241,8 @@ class Consumer(object):
             logger.info('Will not attempt koji write operations')
 
     def __call__(self, message: fedora_messaging.api.Message):
-        #logger.debug(message.topic)
-        #logger.debug(message.body)
+        logger.debug(message.topic)
+        logger.debug(message.body)
 
         # Grab the raw message body and the status from that
         msg = message.body
@@ -251,7 +251,7 @@ class Consumer(object):
         commit = msg['head_commit']['id']
 
         if (repo != self.github_repo_fullname):
-            logger.debug(f'Skipping message from unrelated repo: {repo}')
+            logger.info(f'Skipping message from unrelated repo: {repo}')
             return
 
         if (branch != self.github_repo_branch):
@@ -414,12 +414,12 @@ def find_principal_from_keytab(keytab: str) -> str:
 
     # The principal will be the last column in that line
     principal = line.split(' ')[-1]
-    logger.debug(f'Found principal {principal} in keytab')
+    logger.info(f'Found principal {principal} in keytab')
     return principal
 
 def runcmd(cmd: list, **kwargs: int) -> subprocess.CompletedProcess:
     try:
-        logger.debug(f'Running command: {cmd}')
+        logger.info(f'Running command: {cmd}')
         cp = subprocess.run(cmd, **kwargs)
     except subprocess.CalledProcessError as e:
         logger.error('Running command returned bad exitcode')

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -359,7 +359,9 @@ class Consumer(object):
 
 
     def get_buildsinfo_from_rpmnevras(self, rpmnevras: set) -> dict:
-        # Given a set of rpm NEVRAs get a set of corresponding koji buildids
+        """
+        Given a set of rpm NEVRAs get a set of corresponding koji buildids
+        """
         if not rpmnevras:
             raise ValueError("No nevras to get_builds_from_rpmnevras")
 
@@ -401,17 +403,23 @@ class Consumer(object):
         return buildsinfo
 
     def get_pkglist_in_tag(self, tag: str) -> set:
-        # Given a tag, return the set of packages in its pkglist
+        """
+        Given a tag, return the set of packages in its pkglist
+        """
         pkgs = self.koji_client.listPackages(tagID=tag)
         return set([pkg['package_name'] for pkg in pkgs])
 
     def get_tagged_buildids(self, tag: str) -> set:
-        # Given a tag, return the buildids tagged into it
+        """
+        Given a tag, return the buildids tagged into it
+        """
         builds = self.koji_client.listTagged(tag=tag)
         return set([build['build_id'] for build in builds])
 
 def find_principal_from_keytab(keytab: str) -> str:
-    # Find the pricipal/realm that the keytab is for
+    """
+    Find the pricipal/realm that the keytab is for
+    """
     cmd = ['/usr/bin/klist', '-k', keytab]
     cp = runcmd(cmd, capture_output=True, check=True)
 
@@ -466,21 +474,23 @@ def get_NVRA_from_NEVRA(string: str) -> str:
     return nvra
 
 def parse_lockfile_data(text: str) -> list:
-    # Parse the rpm lockfile format and return a list of rpms in
-    # NEVRA form.
-    # Best documention on the format for now:
-    #     https://github.com/projectatomic/rpm-ostree/commit/8ff0ee9c89ecc0540182b5b506455fc275d27a61
-    #
-    # An example looks something like:
-    #
-    #   {
-    #     "packages": {
-    #       "GeoIP": {
-    #         "evra": "1.6.12-5.fc30.x86_64",
-    #         "digest": "sha256:21dc1220cfdacd089c8c8ed9985801a9d09edb7c26543694cef57ada1d8aafa8"
-    #       }
-    #     }
-    #   }
+    """
+    Parse the rpm lockfile format and return a list of rpms in
+    NEVRA form.
+    Best documention on the format for now:
+        https://github.com/projectatomic/rpm-ostree/commit/8ff0ee9c89ecc0540182b5b506455fc275d27a61
+    
+    An example looks something like:
+    
+      {
+        "packages": {
+          "GeoIP": {
+            "evra": "1.6.12-5.fc30.x86_64",
+            "digest": "sha256:21dc1220cfdacd089c8c8ed9985801a9d09edb7c26543694cef57ada1d8aafa8"
+          }
+        }
+      }
+    """
 
     # The data is JSON (yay)
     data = json.loads(text)

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -430,7 +430,7 @@ def runcmd(cmd: list, **kwargs: int) -> subprocess.CompletedProcess:
         logger.error(f'COMMAND: {cmd}')
         logger.error(f' STDOUT: {e.stdout}')
         logger.error(f' STDERR: {e.stderr}')
-        raise
+        raise e
     return cp # subprocess.CompletedProcess
 
 def get_NVRA_from_NEVRA(string: str) -> str:
@@ -495,7 +495,8 @@ def get_releasever_from_buildroottag(buildroottag: str) -> str:
         # example: f30-build
         releasever = re.search('f(\d\d)', buildroottag).group(1)
     if not releasever:
-        raise
+        raise Exception('Could not derive a releasever for the given'
+                       f'buildroot tag: {buildroottag}')
     return releasever
 
 # The code in this file is expected to be run through fedora messaging

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -1,20 +1,18 @@
 #!/usr/bin/python3
+import dnf.subject
 import fedora_messaging.api
+import hawkey
+import json
+import koji
+import logging
 import os
 import re
 import requests
-import logging
-import json
-import koji
-from koji_cli.lib import watch_tasks
+import subprocess
+import sys
 import traceback
 
-import dnf.subject
-import hawkey
-
-import sys
-import subprocess
-import requests
+from koji_cli.lib import watch_tasks
 
 # Set local logging 
 logger = logging.getLogger(__name__)

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -6,6 +6,7 @@ import requests
 import logging
 import json
 import koji
+from koji_cli.lib import watch_tasks
 
 import dnf.subject
 import hawkey
@@ -336,8 +337,11 @@ class Consumer(object):
                                             '\n\t'.join(map(str, tuples)))
             if self.keytab_file:
                 with self.koji_client.multicall(strict=True) as m:
-                    for (tag, nvr) in tuples:
-                        m.tagBuild(tag=tag, build=nvr)
+                    tasks = [m.tagBuild(tag=tag, build=nvr)
+                                    for (tag, nvr) in tuples]
+                watch_tasks(self.koji_client,
+                            [task.result for task in tasks],
+                            poll_interval=10)
                 logger.info('Tagging done')
 
 


### PR DESCRIPTION
This PR will convert us to using the koji python library. There are several
other small commits in this PR that can be reviewed separately. The
commit summary is:

- move to koji python library
- find_principal_from_keytab no longer class function
- convert some log statements to info
- wait for tagging tasks to complete
- no more bare raises
- catch exceptions and continue