### PR TITLE
config-bot: enable promote-lockfiles

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -15,12 +15,12 @@ trigger.mode = 'periodic'
 trigger.period = '15m'
 method = 'push'
 
-#[promote-lockfiles]
-#source-ref = 'bodhi-updates'
-#target-ref = 'testing-devel'
-#trigger.mode = 'periodic'
-#trigger.period = '24h'
-#method = 'push'
+[promote-lockfiles]
+source-ref = 'bodhi-updates'
+target-ref = 'testing-devel'
+trigger.mode = 'periodic'
+trigger.period = '24h'
+method = 'push'
 
 [propagate-files]
 source-ref = 'testing-devel'


### PR DESCRIPTION
We're in position to enable lockfile promotion now that
coreos-koji-tagger is set up and monitoring the `testing-devel` branch.
Let's do this!