### PR TITLE
config-bot: fix propagate-files logic for deleted files

### DIFF
--- a/config-bot/main
+++ b/config-bot/main
@@ -237,7 +237,16 @@ async def propagate_files(cfg):
             for target_ref in target_refs:
                 git.checkout(target_ref)
 
-                # bring files into the index
+                # We want the same semantics as `rsync --delete`, i.e. delete
+                # files in the target ref no longer in the source ref. We'll do
+                # this by first deleting all the files, then importing the new
+                # files.
+                all_files = git.cmd_output('ls-tree', target_ref,
+                                           '--name-only').splitlines()
+                files_to_delete = [f for f in all_files
+                                   if not matches_patterns(f, skip_files)]
+
+                git.cmd('rm', '-r', '--', *files_to_delete)
                 git.cmd('checkout', source_ref, '--', *files_to_import)
 
                 if git.has_diff():

--- a/config-bot/main
+++ b/config-bot/main
@@ -226,10 +226,10 @@ async def propagate_files(cfg):
             # get the list of files from the source ref
             all_files = git.cmd_output('ls-tree', source_ref,
                                        '--name-only').splitlines()
-            targeted_files = [f for f in all_files
-                              if not matches_patterns(f, skip_files)]
+            files_to_import = [f for f in all_files
+                               if not matches_patterns(f, skip_files)]
 
-            if len(targeted_files) == 0:
+            if len(files_to_import) == 0:
                 eprint(f"No files to propagate from {source_ref}")
                 last_source_ref_checksum = source_ref_checksum
                 continue
@@ -238,7 +238,7 @@ async def propagate_files(cfg):
                 git.checkout(target_ref)
 
                 # bring files into the index
-                git.cmd('checkout', source_ref, '--', *targeted_files)
+                git.cmd('checkout', source_ref, '--', *files_to_import)
 
                 if git.has_diff():
                     git.commit(f"tree: import changes from {source_ref}")


### PR DESCRIPTION
`testing-devel` dropped the `overlay/` dir in favour of `overlay.d`.
However, we weren't deleting the `overlay/` dir in `bodhi-updates`
during file propagation. Make it so that it's like an `rsync --delete`.