### PR TITLE
Revert "config-bot: enable promote-lockfiles"

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -15,12 +15,12 @@ trigger.mode = 'periodic'
 trigger.period = '15m'
 method = 'push'
 
-[promote-lockfiles]
-source-ref = 'bodhi-updates'
-target-ref = 'testing-devel'
-trigger.mode = 'periodic'
-trigger.period = '24h'
-method = 'push'
+#[promote-lockfiles]
+#source-ref = 'bodhi-updates'
+#target-ref = 'testing-devel'
+#trigger.mode = 'periodic'
+#trigger.period = '24h'
+#method = 'push'
 
 [propagate-files]
 source-ref = 'testing-devel'


### PR DESCRIPTION
This reverts commit 9a38dd3ef8dc6810e7935c99a3cdffc8ddb152e3.

There are a few more kinks to be worked out with this whole process.
Let's disable lockfile promotion until we can get them completely
worked out.