### PR TITLE
config-bot: include source ref checksum used in commit message

### DIFF
--- a/config-bot/main
+++ b/config-bot/main
@@ -260,9 +260,11 @@ async def propagate_files(cfg):
 
                 git.cmd('rm', '-r', '--', *files_to_delete)
                 git.cmd('checkout', source_ref, '--', *files_to_import)
+                commit = git.cmd_output('rev-parse', source_ref)
 
                 if git.has_diff():
-                    git.commit(f"tree: import changes from {source_ref}")
+                    git.commit(f"tree: import changes from {source_ref} "
+                               f"at {commit}")
                     try:
                         git.push(target_ref)
                     except Exception as e:

--- a/scripts/promote-config.sh
+++ b/scripts/promote-config.sh
@@ -38,7 +38,7 @@ main() {
         exit 0
     fi
 
-    git commit -m "tree: promote changes from ${src_branch}"
+    git commit -m "tree: promote changes from ${src_branch} at ${fetch_head}"
 }
 
 fatal() {


### PR DESCRIPTION
That way we know exactly what content from what commit was propagated.
Similarly, in the promotion script, include the commit that was
promoted.

Hat tip to Colin who suggested this during a review of the FCOS release
process.