### PR TITLE
coreos-meta-translator: keep arch extensions out of artifact keys

### DIFF
--- a/coreos-meta-translator/trans.py
+++ b/coreos-meta-translator/trans.py
@@ -20,8 +20,8 @@ def ensure_dup(inp, out, inp_key, out_key):
 def url_builder(stream, version, arch, path):
     return f"https://builds.coreos.fedoraproject.org/prod/streams/{stream}/builds/{version}/{arch}/{path}"
 
-def get_extension(path, modifier):
-    return path.rsplit(modifier)[1][1:]
+def get_extension(path, modifier, arch):
+    return path.rsplit(f'{modifier}.{arch}')[1][1:]
 
 
 parser = ArgumentParser()
@@ -84,7 +84,7 @@ for f in files:
             if input_.get("images", {}).get(ga, None) is not None:
                 print(f"   - {ga}")
                 i = input_.get("images").get(ga)
-                ext = get_extension(i.get('path'), ga)
+                ext = get_extension(i.get('path'), ga, arch)
                 arch_dict['media'][ga] = {
                     "artifacts": {
                         ext: {

--- a/coreos-meta-translator/trans.py
+++ b/coreos-meta-translator/trans.py
@@ -142,7 +142,7 @@ for f in files:
                 elif val == out_arch['media'][media_type]:
                     continue
                 else:
-                    raise Exception("differing media type detected: input_file '{}', media_type '{}'".format(input_file, media_type))
+                    raise Exception("differing content detected for media type '{}'".format(media_type))
 
 with open(release_file, 'w') as w:
     json.dump(out, w)


### PR DESCRIPTION
Adding arch extensions to artifact filenames caused the translator to produce artifact keys like `x86_64.qcow2.xz` instead of `qcow2.xz`.  Fix this.

Fixes #47.  Fixes coreos/fedora-coreos-stream-generator#4.

