### PR TITLE
coreos-koji-tagger: support yaml lockfiles

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -7,8 +7,12 @@ ENV PYTHONUNBUFFERED=true
 # Get any latest updates since last container spin
 RUN dnf update -y && dnf clean all
 
-# Install fedmsg/koji libraries
-RUN dnf -y install dnf-plugins-core fedora-messaging koji krb5-workstation && dnf clean all
+# Install necessary (fedmsg/koji/yaml) libraries
+RUN dnf -y install dnf-plugins-core \
+                   fedora-messaging \
+                   koji             \
+                   python3-pyyaml   \
+                   krb5-workstation && dnf clean all
 
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by
 # installing the fedora-packager rpm. We don't need the deps because

--- a/coreos-koji-tagger/README.md
+++ b/coreos-koji-tagger/README.md
@@ -57,11 +57,19 @@ repo will need to be set up publish events to fedmsg using
 the script can pick up the event and process it.
 
 The manifest file(s) will need to be updated to contain information
-about RPMs that are available in the staging koji. I just browsed
-through the
-[lists of builds in the koji web UI](https://koji.stg.fedoraproject.org/koji/builds)
-and found a few. You can test with any rpm, not just ones that are
-in FCOS.
+about RPMs that are available in the staging koji. In order to test
+the full process (including signing) we need to use rpms that were
+built in staging koji and not just imported from prod. Here is a
+oneliner you can use to find those rpms:
+
+```
+$ stg-koji list-builds --after '2019-10-01 11:56:41' --volume=DEFAULT --state=COMPLETE --type=rpm | grep fc31
+```
+
+That command will show you rpmbuilds built in staging koji (`--volume=DEFAULT`) 
+that were successful. The `--after` allows you to limit the search so the query
+takes less time. Grepping for `fc31` helps to find rpms for that release.
+You can test with any rpm, not just ones that are in FCOS.
 
 Once you git push you should notice the tagger pick up the event
 and perform some tagging. The RPMs should eventually end up in the

--- a/coreos-koji-tagger/README.md
+++ b/coreos-koji-tagger/README.md
@@ -98,6 +98,6 @@ podman run -it --rm -v $PWD/:/pwd/ \
 ```
 
 If you'd like you can add `--entrypoint=/bin/bash` and run 
-`/pwd/coreos_koji_tagger.py` directly. If you modify the json at the bottom
+`/pwd/coreos_koji_tagger.py` directly. If you modify the yaml at the bottom
 of the file you can test it out or actually have it call koji
 to apply tags.


### PR DESCRIPTION
- coreos-koji-tagger: update instructions for testing in stage
- coreos-koji-tagger: rework test setup using Mock
- coreos-koji-tagger: support yaml lockfiles
