### PR TITLE
coreos-koji-tagger: return early if no desiredrpms detected

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -322,6 +322,12 @@ class Consumer(object):
                     else:
                         # Log any errors we encounter. 404s are ok, but won't hurt to log
                         logger.warning('URL request error: %s' % r.text.strip())
+        if not desiredrpms:
+            logger.warning('No locked RPMs found!')
+            logger.warning("Does the repo:ref (%s:%s) have any lockfiles?" %
+                            (self.github_repo_fullname, self.github_repo_branch))
+            logger.warning('Continuing...')
+            return
 
         # NOMENCLATURE:
         # 


### PR DESCRIPTION
This shouldn't happen, but we'll return early if we couldn't detect
any desired rpms from the lockfiles in the repo.
