### PR TITLE
coreos-koji-tagger: catch koji.AuthError exception

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -448,8 +448,14 @@ class Consumer(object):
 
     def koji_login(self):
         # If already authenticated then nothing to do
-        if self.koji_client.getLoggedInUser():
-            return
+        # Catch koji.AuthError as that is what happens
+        # when we get logged out.
+        try:
+            if self.koji_client.getLoggedInUser():
+                return
+        except koji.AuthError as e:
+            logger.info('Received koji.AuthError from koji. Re-attempting login.')
+            pass
         # Login!
         principal = find_principal_from_keytab(self.keytab_file)
         self.koji_client.gssapi_login(principal, self.keytab_file)


### PR DESCRIPTION
In our logic to determine if we're still logged in we need to catch
the koji.AuthError exception and pass so that we can fall through to
the code that does the login.

This is a followup to d46a3a1 which was part of
https://github.com/coreos/fedora-coreos-releng-automation/issues/46