### PR TITLE
coreos-ostree-importer: switch to plain http(s) url

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED=true
 RUN dnf update -y && dnf clean all
 
 # Install boto/fedmsg/ostree libraries
-RUN dnf -y install python3-boto3 fedora-messaging ostree && dnf clean all
+RUN dnf -y install fedora-messaging ostree && dnf clean all
 
 # Put the file into a location that can be imported
 ADD coreos_ostree_importer.py /usr/lib/python3.7/site-packages/
@@ -16,12 +16,6 @@ ADD coreos_ostree_importer.py /usr/lib/python3.7/site-packages/
 # Copy in the fedora messaging config into the
 # default location
 ADD fedora-messaging-config.toml /etc/fedora-messaging/config.toml
-
-# Environment variable to be defined by the user that defines the
-# location of the AWS credentials file and also the path to the 
-# filesystem path to the keytab file. If blank it will be ignored
-# and privileged (write) operations won't be attempted
-ENV AWS_CONFIG_FILE ''
 
 # Call fedora-messaging CLI and tell it to use the Consumer
 # class from the included module.

--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:30
+FROM registry.fedoraproject.org/fedora:31
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # periods with no newline get printed immediately to the screen

--- a/coreos-ostree-importer/README.md
+++ b/coreos-ostree-importer/README.md
@@ -18,16 +18,6 @@ From your local git directory:
 podman build -t coreos-ostree-importer .
 ```
 
-Create a file with aws credentials somewhere:
-
-```                                 
-cat <<'EOF' > /dev/shm/secret
-[default]
-aws_access_key_id=keyid
-aws_secret_access_key=key
-EOF
-```
-
 Create some empty OSTree repos:
 
 ```
@@ -43,8 +33,6 @@ Run the importer:
 ```
 podman run -it --rm                                                \
            -v $PWD/:/pwd/                                          \
-           -v /dev/shm/secret:/.aws/config                         \
-           -e AWS_CONFIG_FILE=/.aws/config                         \
            -v /srv/composerepo/:/mnt/koji/compose/ostree/repo/:z   \
            -v /srv/prodrepo/:/mnt/koji/ostree/repo/:z              \
            coreos-ostree-importer
@@ -98,7 +86,7 @@ body = {
     "build_id": "30.20190905.0",
     "stream": "testing",
     "basearch": "x86_64",
-    "commit": "s3://fcos-builds/prod/streams/testing/builds/30.20190905.0/x86_64/ostree-commit.tar",
+    "commit": "https://fcos-builds/prod/streams/testing/builds/30.20190905.0/x86_64/ostree-commit.tar",
     "checksum": "sha256:d01db6939e7387afa2492ac8e2591c53697fc21cf16785585f7f1ac0de692863",
     "ostree_ref": "fedora/x86_64/coreos/testing",
     "ostree_checksum": "b4beca154dab3696fd04f32ddab818102caa9247ec3192403adb9aaecc991bd9",

--- a/coreos-ostree-importer/README.md
+++ b/coreos-ostree-importer/README.md
@@ -83,14 +83,14 @@ cat <<'EOF' > publisher.py
 from fedora_messaging import api, message
 topic = 'org.fedoraproject.prod.coreos.build.request.ostree-import'
 body = {
-    "build_id": "30.20190905.0",
-    "stream": "testing",
+    "build_id": "31.20191217.dev.0",
+    "stream": "bodhi-updates",
     "basearch": "x86_64",
-    "commit": "https://fcos-builds/prod/streams/testing/builds/30.20190905.0/x86_64/ostree-commit.tar",
-    "checksum": "sha256:d01db6939e7387afa2492ac8e2591c53697fc21cf16785585f7f1ac0de692863",
-    "ostree_ref": "fedora/x86_64/coreos/testing",
-    "ostree_checksum": "b4beca154dab3696fd04f32ddab818102caa9247ec3192403adb9aaecc991bd9",
-    "target_repo": "prod"
+    "commit": "https://builds.coreos.fedoraproject.org/prod/streams/bodhi-updates/builds/31.20191217.dev.0/x86_64/fedora-coreos-31.20191217.dev.0-ostree.x86_64.tar",
+    "checksum": "sha256:7aadab5768438e4cd36ea1a6cd60da5408ef2d3696293a1f938989a318325390",
+    "ostree_ref": "fedora/x86_64/coreos/bodhi-updates",
+    "ostree_checksum": "4481da720eedfefd3f6ac8925bffd00c4237fd4a09b01c37c6041e4f0e45a3b9",
+    "target_repo": "compose"
 }
 api.publish(message.Message(topic=topic, body=body))
 EOF

--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -29,14 +29,14 @@ FEDORA_MESSAGING_TOPIC_RESPOND = FEDORA_MESSAGING_TOPIC_LISTEN + ".finished"
 # https://github.com/coreos/fedora-coreos-tracker/issues/198#issuecomment-513944390
 EXAMPLE_MESSAGE_BODY = json.loads("""
 {
-    "build_id": "30.20190905.0",
-    "stream": "testing",
+    "build_id": "31.20191217.dev.0",
+    "stream": "bodhi-updates",
     "basearch": "x86_64",
-    "commit": "https://fcos-builds/prod/streams/testing/builds/30.20190905.0/x86_64/ostree-commit.tar",
-    "checksum": "sha256:d01db6939e7387afa2492ac8e2591c53697fc21cf16785585f7f1ac0de692863",
-    "ostree_ref": "fedora/x86_64/coreos/testing",
-    "ostree_checksum": "b4beca154dab3696fd04f32ddab818102caa9247ec3192403adb9aaecc991bd9",
-    "target_repo": "prod"
+    "commit": "https://builds.coreos.fedoraproject.org/prod/streams/bodhi-updates/builds/31.20191217.dev.0/x86_64/fedora-coreos-31.20191217.dev.0-ostree.x86_64.tar",
+    "checksum": "sha256:7aadab5768438e4cd36ea1a6cd60da5408ef2d3696293a1f938989a318325390",
+    "ostree_ref": "fedora/x86_64/coreos/bodhi-updates",
+    "ostree_checksum": "4481da720eedfefd3f6ac8925bffd00c4237fd4a09b01c37c6041e4f0e45a3b9",
+    "target_repo": "compose"
 }
 """
 )


### PR DESCRIPTION
We'll send the messages with a plain http(s) url so that this importer
doesn't need to be configured with AWS credentials.
