### PR TITLE
config-bot: add some more logging

### DIFF
--- a/config-bot/Dockerfile
+++ b/config-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:30
+FROM registry.fedoraproject.org/fedora:31
 
 RUN dnf -y install git python3-toml python3-aiohttp && dnf clean all
 

--- a/config-bot/main
+++ b/config-bot/main
@@ -327,6 +327,7 @@ class Git:
         self._git_bare.cleanup()
 
     async def __aenter__(self):
+        logging.info("acquiring lock")
         await self._lock.acquire()
         self.cmd('fetch', 'origin', '--prune', '+refs/heads/*:refs/heads/*')
         assert self._git_work is None
@@ -339,13 +340,16 @@ class Git:
         self._git_work = None
         self.cmd('worktree', 'prune')
         self._lock.release()
+        logging.info("releasing lock")
 
     def cmd(self, *args):
         wd = self._git_work or self._git_bare
+        logging.info(f"Running git cmd: {args}")
         subprocess.check_call(['git', *args], cwd=wd.name, env=self._git_env)
 
     def cmd_output(self, *args):
         wd = self._git_work or self._git_bare
+        logging.info(f"Running git cmd: {args}")
         out = subprocess.check_output(['git', *args], cwd=wd.name,
                                       env=self._git_env)
         return out.strip().decode('utf-8')


### PR DESCRIPTION
I think we're hitting an issue somewhere where git can get stuck trying
to fetch from the remote, if e.g. GitHub is being flaky. We should
probably add some timeouts/retries, though for now at least let's add
some logging to make it easier to tell what's going on.

