### PR TITLE
coreos-ostree-importer: various improvements; add requester script

### DIFF
--- a/coreos-ostree-importer/README.md
+++ b/coreos-ostree-importer/README.md
@@ -84,7 +84,7 @@ body = {
     "build_id": "31.20191217.dev.0",
     "stream": "bodhi-updates",
     "basearch": "x86_64",
-    "commit": "https://builds.coreos.fedoraproject.org/prod/streams/bodhi-updates/builds/31.20191217.dev.0/x86_64/fedora-coreos-31.20191217.dev.0-ostree.x86_64.tar",
+    "commit_url": "https://builds.coreos.fedoraproject.org/prod/streams/bodhi-updates/builds/31.20191217.dev.0/x86_64/fedora-coreos-31.20191217.dev.0-ostree.x86_64.tar",
     "checksum": "sha256:7aadab5768438e4cd36ea1a6cd60da5408ef2d3696293a1f938989a318325390",
     "ostree_ref": "fedora/x86_64/coreos/bodhi-updates",
     "ostree_checksum": "4481da720eedfefd3f6ac8925bffd00c4237fd4a09b01c37c6041e4f0e45a3b9",

--- a/coreos-ostree-importer/README.md
+++ b/coreos-ostree-importer/README.md
@@ -56,8 +56,6 @@ The rough steps for setting up a server are:
 
 Optional - to see a web browser view:
 
-- `sudo sed -i -e 's|@RABBITMQ_USER@|rabbitmq|' -e 's|@RABBITMQ_GROUP@|rabbitmq|' /usr/sbin/rabbitmq-plugins`
-    - https://bugzilla.redhat.com/show_bug.cgi?id=1755152
 - `sudo rabbitmq-plugins enable rabbitmq_management`
 - Navigate to `<IP_OF_HOST>:15672` in a web browser and log in with `guest`/`guest`. 
 - Navigate to `Queues` tab to view existing queues/messages.

--- a/coreos-ostree-importer/README.md
+++ b/coreos-ostree-importer/README.md
@@ -99,3 +99,24 @@ You'll have to update the body with new information you'd like to use. Then run:
 ```
 ./publisher.py
 ```
+
+## Fedora Messaging sender from the Fedora CoreOS Pipeline
+
+Included in this directory is a file (`send-ostree-import-request.py`)
+that is not used by the `coreos-ostree-importer`
+at all. It is used by the
+[Fedora CoreOS Pipeline](https://github.com/coreos/fedora-coreos-pipeline.git)
+to send the request to the importer. It made sense to co-locate the
+requester and importer in the same code repo/directory.
+
+Here's how you might send a request using `fcos-pipeline-ostree-import-request.py`: 
+
+
+```
+cosa buildprep --build=31.20200212.20.0 s3://fcos-builds/prod/streams/testing-devel/builds
+/usr/lib/coreos-assembler/send-ostree-import-request.py \
+        --fedmsg-conf /srv/fedora-messaging-config.toml \
+        --build 31.20200212.20.0 --stg \
+        --s3 fcos-builds/prod/streams/testing-devel \
+        --repo compose
+```

--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -73,7 +73,7 @@ class Consumer(object):
             traceback.print_exc()
             logger.error("###################################")
             logger.error("Replying with a FAILURE message...")
-            send_message(msg=message.body, status="FAILURE")
+            send_message(msg=message.body, status="FAILURE", failure_message=str(e))
             logger.error("\t continuing...")
             pass
 
@@ -159,13 +159,15 @@ def runcmd(cmd: list, **kwargs: int) -> subprocess.CompletedProcess:
     return cp  # subprocess.CompletedProcess
 
 
-def send_message(msg: dict, status: str):
+def send_message(msg: dict, status: str, failure_message: str = ""):
     # Send back a message with all the original message body
-    # along with an additional `status:` header with either
-    # `SUCCESS` or `FAILURE`.
+    # along with additional `status:` and `failure-message` headers.
+    body = {"status": status, **msg}
+    if failure_message:
+        body["failure-message"] = failure_message
     fedora_messaging.api.publish(
         fedora_messaging.message.Message(
-            topic=FEDORA_MESSAGING_TOPIC_RESPOND, body={"status": status, **msg}
+            topic=FEDORA_MESSAGING_TOPIC_RESPOND, body=body
         )
     )
 

--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -46,8 +46,6 @@ KNOWN_OSTREE_REPOS = {
     "compose": "/mnt/koji/compose/ostree/repo",
 }
 
-# Given a repo (and thus an input JSON) analyze existing koji tag set
-# and tag in any missing packages
 class Consumer(object):
     def __init__(self):
         # Check the possible repos to make sure they exist

--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -89,7 +89,6 @@ class Consumer(object):
         commit_url = msg["commit_url"]
         ostree_checksum = msg["ostree_checksum"]
         ostree_ref = msg["ostree_ref"]
-        stream = msg["stream"]
         target_repo = msg["target_repo"]
 
         # Qualify arguments
@@ -101,6 +100,11 @@ class Consumer(object):
         sha256sum = checksum[7:]
         target_repo_path = KNOWN_OSTREE_REPOS[target_repo]
         source_repo_path = None
+
+        logger.info(
+            f"Processing request to import {build_id} into the "
+            f"{ostree_ref} branch of the {target_repo} repo."
+        )
 
         # Detect if the commit already exists in the target repo
         # NOTE: We assume here that an import won't be requested twice for

--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -27,7 +27,8 @@ FEDORA_MESSAGING_TOPIC_RESPOND = FEDORA_MESSAGING_TOPIC_LISTEN + ".finished"
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import&delta=100000
 # The schema was originally designed in:
 # https://github.com/coreos/fedora-coreos-tracker/issues/198#issuecomment-513944390
-EXAMPLE_MESSAGE_BODY = json.loads("""
+EXAMPLE_MESSAGE_BODY = json.loads(
+    """
 {
     "build_id": "31.20191217.dev.0",
     "stream": "bodhi-updates",
@@ -45,6 +46,7 @@ KNOWN_OSTREE_REPOS = {
     "prod": "/mnt/koji/ostree/repo",
     "compose": "/mnt/koji/compose/ostree/repo",
 }
+
 
 class Consumer(object):
     def __init__(self):

--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -86,7 +86,7 @@ class Consumer(object):
         basearch = msg["basearch"]
         build_id = msg["build_id"]
         checksum = msg["checksum"]
-        commit_url = msg["commit"]
+        commit_url = msg["commit_url"]
         ostree_checksum = msg["ostree_checksum"]
         ostree_ref = msg["ostree_ref"]
         stream = msg["stream"]

--- a/coreos-ostree-importer/fedora-messaging-config.toml
+++ b/coreos-ostree-importer/fedora-messaging-config.toml
@@ -1,5 +1,5 @@
 # This file is in the TOML format.
-amqp_url = "amqps://coreos:@rabbitmq.fedoraproject.org/%2Fpubsub"
+amqp_url = "amqps://coreos-ostree-importer:@rabbitmq.fedoraproject.org/%2Fpubsub"
 callback = "fedora_messaging.example:printer"
 
 # pick up the key/cert from the same directory as the messaging config
@@ -21,7 +21,7 @@ auto_delete = false
 arguments = {}
 
 # We'll use the coreos queue name
-[queues.coreos]
+[queues.coreos-ostree-importer]
 durable = true
 auto_delete = false
 exclusive = true
@@ -29,7 +29,7 @@ arguments = {}
 
 # We care about the ostree-import message topic
 [[bindings]]
-queue = "coreos"
+queue = "coreos-ostree-importer"
 exchange = "amq.topic"
 routing_keys = ["org.fedoraproject.prod.coreos.build.request.ostree-import"]
 

--- a/coreos-ostree-importer/send-ostree-import-request.py
+++ b/coreos-ostree-importer/send-ostree-import-request.py
@@ -11,7 +11,8 @@ import argparse
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Pick up libraries we use that are delivered along with COSA
+sys.path.insert(0, '/usr/lib/coreos-assembler')
 from cosalib.meta import GenericBuildMeta
 from cosalib.fedora_messaging_request import send_message
 

--- a/coreos-ostree-importer/send-ostree-import-request.py
+++ b/coreos-ostree-importer/send-ostree-import-request.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""
+    This script is meant to be run from the Fedora CoreOS build
+    pipeline (see https://github.com/coreos/fedora-coreos-pipeline.git)
+    It makes an OSTree import request to the coreos-ostree-importer
+    running in Fedora's Infra OpenShift cluster.
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.meta import GenericBuildMeta
+from cosalib.fedora_messaging_request import send_message
+
+# Example datagrepper URLs to inspect sent messages:
+# https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import&delta=100000
+# https://apps.stg.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.stg.coreos.build.request.ostree-import&delta=100000
+# https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import.finished&delta=100000
+# https://apps.stg.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.stg.coreos.build.request.ostree-import.finished&delta=100000
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build", help="Build ID", default="latest")
+    parser.add_argument(
+        "--fedmsg-conf",
+        metavar="CONFIG.TOML",
+        required=True,
+        help="fedora-messaging config file for publishing",
+    )
+    parser.add_argument(
+        "--stg", action="store_true", help="target the stg infra rather than prod"
+    )
+    parser.add_argument(
+        "--s3",
+        metavar="<BUCKET>[/PREFIX]",
+        required=True,
+        help="bucket and prefix to S3 builds/ dir",
+    )
+    parser.add_argument(
+        "--repo",
+        choices=["prod", "compose"],
+        required=True,
+        help="the name of the OSTree repo within Fedora to import into",
+    )
+    return parser.parse_args()
+
+
+def send_ostree_import_request(args):
+    buildid = args.build
+    build = GenericBuildMeta(build=buildid)
+
+    bucket, prefix = get_bucket_and_prefix(args.s3)
+    basearch = build["coreos-assembler.basearch"]
+    environment = "prod"
+    if args.stg:
+        environment = "stg"
+
+    # Example: https://fcos-builds.s3.amazonaws.com/prod/streams/stable/builds/31.20200127.3.0/x86_64/fedora-coreos-31.20200127.3.0-ostree.x86_64.tar
+    commit_url = f"https://{bucket}.s3.amazonaws.com/{prefix}/builds/{buildid}/{basearch}/{build['images']['ostree']['path']}"
+
+    # response = send_request_and_wait_for_response(
+    send_message(
+        request_type="ostree-import",
+        config=args.fedmsg_conf,
+        environment=environment,
+        body={
+            "build_id": buildid,
+            "basearch": basearch,
+            "commit_url": commit_url,
+            "checksum": "sha256:" + build["images"]["ostree"]["sha256"],
+            "ostree_ref": build["ref"],
+            "ostree_checksum": build["ostree-commit"],
+            "target_repo": args.repo,
+        },
+    )
+    # validate_response(response)
+
+
+def get_bucket_and_prefix(path):
+    split = path.split("/", 1)
+    if len(split) == 1:
+        return (split[0], "")
+    return split
+
+
+def validate_response(response):
+    if response["status"].lower() == "failure":
+        # https://pagure.io/robosignatory/pull-request/38
+        if "failure-message" not in response:
+            raise Exception("Signing failed")
+        raise Exception(f"Signing failed: {response['failure-message']}")
+    assert response["status"].lower() == "success", str(response)
+
+
+def main():
+    args = parse_args()
+    send_ostree_import_request(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
There are various improvements to the ostree importer in this patchset, including
the addition of send-ostree-import-request.py. Please see individual commit
messages for more information.