### PR TITLE
coreos-ostree-importer: misc fixes

### DIFF
--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -17,9 +17,10 @@ import urllib.request
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-FEDORA_MESSAGING_TOPIC_LISTEN = (
-    "org.fedoraproject.prod.coreos.build.request.ostree-import"
-)
+# This should be one of:
+#   - org.fedoraproject.prod.coreos.build.request.ostree-import
+#   - org.fedoraproject.stg.coreos.build.request.ostree-import
+FEDORA_MESSAGING_TOPIC_LISTEN = fedora_messaging.config.conf.get("bindings")[0]["routing_keys"][0]
 FEDORA_MESSAGING_TOPIC_RESPOND = FEDORA_MESSAGING_TOPIC_LISTEN + ".finished"
 
 
@@ -288,7 +289,7 @@ if __name__ == "__main__":
     logger.addHandler(sh)
 
     m = fedora_messaging.api.Message(
-        topic="org.fedoraproject.prod.coreos.build.request.ostree-import",
+        topic=FEDORA_MESSAGING_TOPIC_LISTEN,
         body=EXAMPLE_MESSAGE_BODY,
     )
     c = Consumer()

--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -33,7 +33,7 @@ EXAMPLE_MESSAGE_BODY = json.loads(
     "build_id": "31.20191217.dev.0",
     "stream": "bodhi-updates",
     "basearch": "x86_64",
-    "commit": "https://builds.coreos.fedoraproject.org/prod/streams/bodhi-updates/builds/31.20191217.dev.0/x86_64/fedora-coreos-31.20191217.dev.0-ostree.x86_64.tar",
+    "commit_url": "https://builds.coreos.fedoraproject.org/prod/streams/bodhi-updates/builds/31.20191217.dev.0/x86_64/fedora-coreos-31.20191217.dev.0-ostree.x86_64.tar",
     "checksum": "sha256:7aadab5768438e4cd36ea1a6cd60da5408ef2d3696293a1f938989a318325390",
     "ostree_ref": "fedora/x86_64/coreos/bodhi-updates",
     "ostree_checksum": "4481da720eedfefd3f6ac8925bffd00c4237fd4a09b01c37c6041e4f0e45a3b9",

--- a/coreos-ostree-importer/fedora-messaging-config.toml
+++ b/coreos-ostree-importer/fedora-messaging-config.toml
@@ -8,6 +8,13 @@
 amqp_url = "amqps://coreos-ostree-importer:@rabbitmq.fedoraproject.org/%2Fpubsub"
 callback = "fedora_messaging.example:printer"
 
+# In the production/private rabbitmq servers clients can't create
+# queues dynamically. The client defaults to trying to create them.
+# Setting this to true means the client will not attempt to create
+# the queue on the server, but will just check to make sure it exists
+# and configured correctly.
+#passive_declares = true
+
 # pick up the key/cert from the same directory as the messaging config
 [tls]
 ca_cert = "/etc/fedora-messaging/cacert.pem"

--- a/coreos-ostree-importer/fedora-messaging-config.toml
+++ b/coreos-ostree-importer/fedora-messaging-config.toml
@@ -1,4 +1,10 @@
-# This file is in the TOML format.
+# This config is meant to be used for local testing of CoreOS OSTree
+# Importer. The real config that will be used is over in Fedora's
+# Ansible repo [1]. In order to test this with a local setup you'll
+# need to change the amqp url to something like: `amqp_url = "amqp://192.168.121.2"`
+#
+# [1] https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/openshift-apps/coreos-ostree-importer/templates/fedora-messaging.toml#n23
+
 amqp_url = "amqps://coreos-ostree-importer:@rabbitmq.fedoraproject.org/%2Fpubsub"
 callback = "fedora_messaging.example:printer"
 


### PR DESCRIPTION
A few fixes/updates to the coreos-ostree-importer code.

-  coreos-ostree-importer: add passive_declares to the config
- coreos-ostree-importer: add comment to top of the config file
- coreos-ostree-importer: detect the message topic from the config
- coreos-ostree-importer: fix example message payload
