### PR TITLE
Dockerfiles: remove the `dnf clean all` where it doesn't make sense

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -5,19 +5,19 @@ FROM registry.fedoraproject.org/fedora:31
 ENV PYTHONUNBUFFERED=true
 
 # Get any latest updates since last container spin
-RUN dnf update -y && dnf clean all
+RUN dnf update -y
 
 # Install necessary (fedmsg/koji/yaml) libraries
 RUN dnf -y install dnf-plugins-core \
                    fedora-messaging \
                    koji             \
                    python3-pyyaml   \
-                   krb5-workstation && dnf clean all
+                   krb5-workstation
 
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by
 # installing the fedora-packager rpm. We don't need the deps because
 # we aren't building anything.
-RUN dnf download fedora-packager && rpm -ivh --nodeps fedora-packager*rpm && rm fedora-packager*rpm && dnf clean all
+RUN dnf download fedora-packager && rpm -ivh --nodeps fedora-packager*rpm && rm fedora-packager*rpm
 
 RUN mkdir /work
 WORKDIR /work

--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -5,10 +5,10 @@ FROM registry.fedoraproject.org/fedora:31
 ENV PYTHONUNBUFFERED=true
 
 # Get any latest updates since last container spin
-RUN dnf update -y && dnf clean all
+RUN dnf update -y
 
 # Install boto/fedmsg/ostree libraries
-RUN dnf -y install fedora-messaging ostree && dnf clean all
+RUN dnf -y install fedora-messaging ostree
 
 # Put the file into a location that can be imported
 ADD coreos_ostree_importer.py /usr/lib/python3.7/site-packages/


### PR DESCRIPTION
Rather than hit our fedora servers 2 or 3 times for the metadata let's
just let the cache bake in the images.