### PR TITLE
coreos-ostree-importer: sender: switch to waiting on request response

### DIFF
--- a/coreos-ostree-importer/send-ostree-import-request.py
+++ b/coreos-ostree-importer/send-ostree-import-request.py
@@ -14,7 +14,7 @@ import sys
 # Pick up libraries we use that are delivered along with COSA
 sys.path.insert(0, '/usr/lib/coreos-assembler')
 from cosalib.meta import GenericBuildMeta
-from cosalib.fedora_messaging_request import send_message
+from cosalib.fedora_messaging_request import send_request_and_wait_for_response
 
 # Example datagrepper URLs to inspect sent messages:
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import&delta=100000
@@ -63,8 +63,7 @@ def send_ostree_import_request(args):
     # Example: https://fcos-builds.s3.amazonaws.com/prod/streams/stable/builds/31.20200127.3.0/x86_64/fedora-coreos-31.20200127.3.0-ostree.x86_64.tar
     commit_url = f"https://{bucket}.s3.amazonaws.com/{prefix}/builds/{buildid}/{basearch}/{build['images']['ostree']['path']}"
 
-    # response = send_request_and_wait_for_response(
-    send_message(
+    response = send_request_and_wait_for_response(
         request_type="ostree-import",
         config=args.fedmsg_conf,
         environment=environment,
@@ -78,7 +77,7 @@ def send_ostree_import_request(args):
             "target_repo": args.repo,
         },
     )
-    # validate_response(response)
+    validate_response(response)
 
 
 def get_bucket_and_prefix(path):

--- a/coreos-ostree-importer/send-ostree-import-request.py
+++ b/coreos-ostree-importer/send-ostree-import-request.py
@@ -90,7 +90,6 @@ def get_bucket_and_prefix(path):
 
 def validate_response(response):
     if response["status"].lower() == "failure":
-        # https://pagure.io/robosignatory/pull-request/38
         if "failure-message" not in response:
             raise Exception("Signing failed")
         raise Exception(f"Signing failed: {response['failure-message']}")

--- a/coreos-ostree-importer/send-ostree-import-request.py
+++ b/coreos-ostree-importer/send-ostree-import-request.py
@@ -22,6 +22,10 @@ from cosalib.fedora_messaging_request import send_request_and_wait_for_response
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import.finished&delta=100000
 # https://apps.stg.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.stg.coreos.build.request.ostree-import.finished&delta=100000
 
+# Since downloading the ostree tarball can take some time let's give
+# it 10 minutes to do the job.
+IMPORT_REQUEST_TIMEOUT = 60*10
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -67,6 +71,7 @@ def send_ostree_import_request(args):
         request_type="ostree-import",
         config=args.fedmsg_conf,
         environment=environment,
+        request_timeout=IMPORT_REQUEST_TIMEOUT,
         body={
             "build_id": buildid,
             "basearch": basearch,

--- a/coreos-ostree-importer/send-ostree-import-request.py
+++ b/coreos-ostree-importer/send-ostree-import-request.py
@@ -95,8 +95,8 @@ def get_bucket_and_prefix(path):
 def validate_response(response):
     if response["status"].lower() == "failure":
         if "failure-message" not in response:
-            raise Exception("Signing failed")
-        raise Exception(f"Signing failed: {response['failure-message']}")
+            raise Exception("Importing failed")
+        raise Exception(f"Importing failed: {response['failure-message']}")
     assert response["status"].lower() == "success", str(response)
 
 


### PR DESCRIPTION
A few commits. The most important being the switch to waiting on a response
that the ostree importer has finished before continuing.

- coreos-ostree-importer: sender: bump timeout to 10 minutes
- coreos-ostree-importer: sender: switch to waiting on request response
- coreos-ostree-importer: sender: clean up unrelated comment
