### PR TITLE
coreos-ostree-importer: configure/check for group writable 

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -7,8 +7,12 @@ ENV PYTHONUNBUFFERED=true
 # Get any latest updates since last container spin
 RUN dnf update -y
 
-# Install boto/fedmsg/ostree libraries
-RUN dnf -y install fedora-messaging ostree
+# Install needed rpms
+# Grab ostree from koji for now for https://github.com/ostreedev/ostree/pull/1984
+RUN dnf -y install \
+        fedora-messaging \
+        https://kojipkgs.fedoraproject.org//packages/ostree/2020.1/2.fc31/x86_64/ostree-2020.1-2.fc31.x86_64.rpm \
+        https://kojipkgs.fedoraproject.org//packages/ostree/2020.1/2.fc31/x86_64/ostree-libs-2020.1-2.fc31.x86_64.rpm
 
 # Configure a umask of 0002 which will allow for the group permissions
 # to include write for newly created files. We need this because we'd

--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -10,6 +10,18 @@ RUN dnf update -y
 # Install boto/fedmsg/ostree libraries
 RUN dnf -y install fedora-messaging ostree
 
+# Configure a umask of 0002 which will allow for the group permissions
+# to include write for newly created files. We need this because we'd
+# like to access the OSTree repos from two different Kubernetes pods,
+# which will have different UIDs but the same GID.
+# See: https://pagure.io/releng/issue/8811#comment-616490
+#
+# This is also done within the coreos-ostree-importer-wrapper script,
+# but we also want it done in the container because admins may run some
+# ostree operations by hand from a bash prompt and we want those
+# operations to not put the repo in a bad state.
+RUN echo 'umask 0002' > /etc/profile.d/umask-for-openshift.sh
+
 # Put the file into a location that can be imported
 ADD coreos_ostree_importer.py /usr/lib/python3.7/site-packages/
 
@@ -17,6 +29,8 @@ ADD coreos_ostree_importer.py /usr/lib/python3.7/site-packages/
 # default location
 ADD fedora-messaging-config.toml /etc/fedora-messaging/config.toml
 
-# Call fedora-messaging CLI and tell it to use the Consumer
-# class from the included module.
-CMD fedora-messaging consume --callback=coreos_ostree_importer:Consumer
+# Copy in the wrapper that starts the importer
+ADD coreos-ostree-importer-wrapper /usr/local/bin/
+
+# Call the wrapper
+CMD ["/usr/local/bin/coreos-ostree-importer-wrapper"]

--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.fedoraproject.org/fedora:31
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
-# periods with no newline get printed immediately to the screen
+# output immediately comes to the console
 ENV PYTHONUNBUFFERED=true
 
 # Get any latest updates since last container spin

--- a/coreos-ostree-importer/coreos-ostree-importer-wrapper
+++ b/coreos-ostree-importer/coreos-ostree-importer-wrapper
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+
+# This is a wrapper script that simply sets the appropriate umask and
+# then execs fedora-messaging to start the coreos-ostree-importer
+
+set -e
+
+# Configure a umask of 0002 which will allow for the group permissions
+# to include write for newly created files. We need this because we'd
+# like to access the OSTree repos from two different Kubernetes pods,
+# which will have different UIDs but the same GID.
+# See: https://pagure.io/releng/issue/8811#comment-616490
+umask 0002
+
+# exec to call fedora-messaging CLI and tell it to use the Consumer
+exec fedora-messaging consume --callback=coreos_ostree_importer:Consumer


### PR DESCRIPTION
We are going to be running two applications with access to the ostree repos:
`coreos-ostree-importer` and `fedora-ostree-pruner`. In order to do this in
OpenShift we need everything to be group writable. This PR sets the umask
such that new files are creating group writable and also adds a check to make
sure that directories in the repo have the group writable bit set.