### PR TITLE
coreos-ostree-importer: support manual runs with datagrepper URL inputs

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf update -y
 # Grab ostree from koji for now for https://github.com/ostreedev/ostree/pull/1984
 RUN dnf -y install \
         fedora-messaging \
+        python-requests  \
         https://kojipkgs.fedoraproject.org//packages/ostree/2020.1/2.fc31/x86_64/ostree-2020.1-2.fc31.x86_64.rpm \
         https://kojipkgs.fedoraproject.org//packages/ostree/2020.1/2.fc31/x86_64/ostree-libs-2020.1-2.fc31.x86_64.rpm
 


### PR DESCRIPTION
This can be useful for testing or if we ever need to manually trigger
imports if the importer fails for any reason like:

- there was a failure when importing a previous version and we want to trigger a new import
- the importer was down and not able to respond to a previous request

Should be able to execute like:

./coreos_ostree_importer.py 'https://apps.fedoraproject.org/datagrepper/id?id=2020-32c268dc-36ba-4cef-be6a-f4969a0c83af&is_raw=true&size=extra-large'
