### PR TITLE
coreos-koji-tagger: retry koji login for 15m

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -12,6 +12,7 @@ RUN dnf -y install dnf-plugins-core \
                    fedora-messaging \
                    koji             \
                    python3-pyyaml   \
+                   python3-tenacity \
                    krb5-workstation
 
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by


### PR DESCRIPTION
We're hitting this pretty frequently in prod now. Let's try retrying for
a bit in case it's simply due to Koji restarting or something.

See: https://github.com/coreos/fedora-coreos-releng-automation/issues/70