### PR TITLE
config-bot: enable propagate-files for next-devel

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -26,6 +26,9 @@ method = 'push'
 source-ref = 'testing-devel'
 target-refs = [
     'bodhi-updates',
+    # for now we inherit from testing-devel; see discussions starting from
+    # https://github.com/coreos/fedora-coreos-config/pull/180#issuecomment-534697400
+    'next-devel',
 ]
 skip-files = [
     'manifest.yaml',


### PR DESCRIPTION
For now we inherit from testing-devel; see discussions starting from:

https://github.com/coreos/fedora-coreos-config/pull/180#issuecomment-534697400