### PR TITLE
coreos-ostree-importer: remove permissions check for now

### DIFF
--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -198,7 +198,8 @@ def assert_dirs_permissions(path: str):
             logger.warning(f"Directory {d} does not have gid=263!")
             founderror = True
     if founderror:
-        raise Exception(f"Found directories with unexpected permissions/ownership")
+        print(f"XXX: Found directories with unexpected permissions/ownership")
+        #raise Exception(f"Found directories with unexpected permissions/ownership")
 
 
 def runcmd(cmd: list, **kwargs: int) -> subprocess.CompletedProcess:


### PR DESCRIPTION
We need to update a few pieces to set their umask to 0002 when modifying
files in the repos. robosignatory and pungi are two that still need to
be updated. For now let's just print the warnings and not error out.