### PR TITLE
versionary: temporarily mark next-devel and next as unlocked

### DIFF
--- a/scripts/versionary.py
+++ b/scripts/versionary.py
@@ -23,6 +23,9 @@ UNLOCKED_STREAMS = [
     'branched',
     'bodhi-updates-testing',
     'bodhi-updates',
+    # XXX: temporary hack (see https://github.com/coreos/fedora-coreos-config/pull/351)
+    'next-devel',
+    'next',
 ]
 
 # https://github.com/coreos/fedora-coreos-tracker/issues/211#issuecomment-543547587


### PR DESCRIPTION
As per https://github.com/coreos/fedora-coreos-config/pull/351.

Otherwise, it's (quite rightly) not happy to use the "unlocked"
semantics for versioning.

This will automatically error out again once we add lockfiles back in,
so we'll definitely not forget to drop this hack.