### PR TITLE
config-bot: disable promote-lockfiles too

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -16,12 +16,13 @@ github.token.path = '/var/run/secrets/coreos.fedoraproject.org/github-token/toke
 #trigger.period = '15m'
 #method = 'push'
 
-[promote-lockfiles]
-source-ref = 'bodhi-updates'
-target-ref = 'testing-devel'
-trigger.mode = 'periodic'
-trigger.period = '24h'
-method = 'push'
+# XXX: disabled for now: https://github.com/coreos/fedora-coreos-config/pull/335#issuecomment-610634917
+#[promote-lockfiles]
+#source-ref = 'bodhi-updates'
+#target-ref = 'testing-devel'
+#trigger.mode = 'periodic'
+#trigger.period = '24h'
+#method = 'push'
 
 [propagate-files]
 source-ref = 'testing-devel'


### PR DESCRIPTION
Otherwise every time we'll try to manually bump the testing-devel
lockfile, it'll create a diff from bodhi-updates which config-bot will
want to reconcile.