### PR TITLE
coreos-ostree-importer: use newer ostree from koji

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -8,11 +8,13 @@ ENV PYTHONUNBUFFERED=true
 RUN dnf update -y
 
 # Install needed rpms
+# Grab ostree from koji for now for https://github.com/ostreedev/ostree/pull/1984
 RUN dnf -y install \
         fedora-messaging \
         python-requests  \
-        ostree           \
-        strace
+        strace           \
+        https://kojipkgs.fedoraproject.org/packages/ostree/2020.3/3.fc31/x86_64/ostree-2020.3-3.fc31.x86_64.rpm \
+        https://kojipkgs.fedoraproject.org/packages/ostree/2020.3/3.fc31/x86_64/ostree-libs-2020.3-3.fc31.x86_64.rpm
 
 # Configure a umask of 0002 which will allow for the group permissions
 # to include write for newly created files. We need this because we'd


### PR DESCRIPTION
Grab ostree-2020.3-3.fc31 from koji so we can hopefully get over
some concurrency issues. https://github.com/ostreedev/ostree/pull/2077