### PR TITLE
coreos-ostree-importer: update send request timeout

### DIFF
--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -292,7 +292,7 @@ def ostree_pull_local(srcrepo: str, dstrepo: str, branch: str, commit: str):
     cmd = ["ostree", f"--repo={dstrepo}", "pull-local", srcrepo, commit]
     runcmd(cmd)
     # update branch
-    if branch_exists:
+    if ostree_branch_exists(repo=dstrepo, branch=branch):
         cmd = ["ostree", f"--repo={dstrepo}", "reset", branch, commit]
     else:
         cmd = ["ostree", f"--repo={dstrepo}", "refs", f"--create={branch}", commit]

--- a/coreos-ostree-importer/send-ostree-import-request.py
+++ b/coreos-ostree-importer/send-ostree-import-request.py
@@ -22,6 +22,8 @@ from cosalib.fedora_messaging_request import send_request_and_wait_for_response
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import.finished&delta=100000
 # https://apps.stg.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.stg.coreos.build.request.ostree-import.finished&delta=100000
 
+# Give the importer some time to do the import
+OSTREE_IMPORTER_REQUEST_TIMEOUT_SEC = 15 * 60
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -67,6 +69,7 @@ def send_ostree_import_request(args):
         request_type="ostree-import",
         config=args.fedmsg_conf,
         environment=environment,
+        request_timeout=OSTREE_IMPORTER_REQUEST_TIMEOUT_SEC,
         body={
             "build_id": buildid,
             "basearch": basearch,


### PR DESCRIPTION
This should give the importer enough time to actually process and
do the import. The current default timeout of 1 minute is not enough.

Also fixed a bug (see first commit). 