### PR TITLE
Revert "versionary: temporarily mark next-devel and next as unlocked"

### DIFF
--- a/scripts/versionary.py
+++ b/scripts/versionary.py
@@ -23,9 +23,6 @@ UNLOCKED_STREAMS = [
     'branched',
     'bodhi-updates-testing',
     'bodhi-updates',
-    # XXX: temporary hack (see https://github.com/coreos/fedora-coreos-config/pull/351)
-    'next-devel',
-    'next',
 ]
 
 # https://github.com/coreos/fedora-coreos-tracker/issues/211#issuecomment-543547587


### PR DESCRIPTION
This reverts commit ccae9dc994c65b324320fef014bd5337e3d46c7c.

We don't need this anymore since we've added lockfiles back to
`next-devel` in https://github.com/coreos/fedora-coreos-config/pull/370.
(The `next` stream doesn't yet have lockfiles, but the next release
there should since we'll be promoting from `next-devel`.)