### PR TITLE
Switch fedora-messaging based apps to use --callback-file

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -42,8 +42,8 @@ RUN sed -i 's/format =.*$/format = "%(asctime)s %(levelname)s %(name)s - %(messa
 # We only care about org.fedoraproject.prod.github.push messages
 RUN sed -i 's/^routing_keys.*$/routing_keys = ["org.fedoraproject.prod.github.push"]/' /work/my_config.toml
 
-# Put the file into a location that can be imported
-ADD coreos_koji_tagger.py /usr/lib/python3.7/site-packages/
+# Add coreos_koji_tagger to the container
+ADD coreos_koji_tagger.py /work/
 
 # Environment variable to be defined by the user that defines the
 # filesystem path to the keytab file. If blank it will be ignored
@@ -61,5 +61,5 @@ ENV COREOS_KOJI_TAGGER_KEYTAB_FILE ''
 RUN sed -i 's/^    default_ccache_name/#   default_ccache_name/' /etc/krb5.conf
 
 # Call fedora-messaging CLI and tell it to use the Consumer
-# class from the included module.
-CMD fedora-messaging --conf /work/my_config.toml consume --callback=coreos_koji_tagger:Consumer
+# class from coreos_koji_tagger.py
+CMD fedora-messaging --conf /work/my_config.toml consume --callback-file=/work/coreos_koji_tagger.py:Consumer

--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -26,8 +26,8 @@ RUN dnf -y install \
 # operations to not put the repo in a bad state.
 RUN echo 'umask 0002' > /etc/profile.d/umask-for-openshift.sh
 
-# Put the file into a location that can be imported
-ADD coreos_ostree_importer.py /usr/lib/python3.7/site-packages/
+# Add coreos_ostree_importer to the container
+ADD coreos_ostree_importer.py /usr/local/lib/
 
 # Copy in the fedora messaging config into the
 # default location

--- a/coreos-ostree-importer/coreos-ostree-importer-wrapper
+++ b/coreos-ostree-importer/coreos-ostree-importer-wrapper
@@ -13,4 +13,4 @@ set -e
 umask 0002
 
 # exec to call fedora-messaging CLI and tell it to use the Consumer
-exec fedora-messaging consume --callback=coreos_ostree_importer:Consumer
+exec fedora-messaging consume --callback-file=/usr/local/lib/coreos_ostree_importer.py:Consumer


### PR DESCRIPTION
With the switch to f32 the version of python is now 3.8 so the
`/usr/lib/python3.7/site-packages/` path we were using previously
no longer works. Since fedora-messaging now supports providing
a path directly to a file via `--callback-file`, let's use that
behavior instead.