### PR TITLE
coreos-meta-translator: add gcp cloud launchable to release.json

### DIFF
--- a/coreos-meta-translator/trans.py
+++ b/coreos-meta-translator/trans.py
@@ -102,6 +102,15 @@ for f in files:
                     "image": ami_dict["hvm"]
                 }
 
+        # GCP specific additions
+        if input_.get("gcp", None) is not None:
+            arch_dict["media"]["gcp"] = arch_dict["media"].get("gcp", {})
+            arch_dict["media"]["gcp"]["image"] = arch_dict["media"]["gcp"].get("image", {})
+            arch_dict["media"]["gcp"]["image"].update(input_.get("gcp", {}))
+            arch_dict["media"]["gcp"]["image"]["name"] = arch_dict["media"]["gcp"]["image"].pop("image")
+            # remove the url as we haven't decided to expose that information publicly yet
+            arch_dict["media"]["gcp"]["image"].pop("url")
+
         # metal specific additions
         arch_dict["media"]["metal"] = arch_dict["media"].get("metal", {})
         arch_dict["media"]["metal"]["artifacts"] = arch_dict["media"]["metal"].get("artifacts", {})


### PR DESCRIPTION
As AMIs have their own field `images` under the `aws` key, I think it might make sense for GCP to follow the same rule, adding an `image` field under the `gcp` key and rename the original `image` key to `name`.

If this is reasonable, it should be followed by updating `fedora-coreos-stream-generator` to support this PR. Finally, download page could read the GCP cloud launchable metadata from e.g. `stable.json` instead of `meta.json`

Related: https://github.com/coreos/fedora-coreos-tracker/issues/494
Signed-off-by: Allen Bai <abai@redhat.com>