### PR TITLE
coreos-ostree-importer: handle partial commits

### DIFF
--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -321,7 +321,12 @@ def ostree_repo_exists(repo: str) -> bool:
 
 def ostree_commit_exists(repo: str, commit: str) -> bool:
     cmd = ["ostree", f"--repo={repo}", "show", commit]
-    return runcmd(cmd, check=False).returncode == 0
+    if runcmd(cmd, check=False).returncode != 0:
+        return False
+    # the commit object exists, but it may be partial
+    if os.path.exists(os.path.join(repo, 'state', f'{commit}.commitpartial')):
+        return False
+    return True
 
 
 def ostree_branch_exists(repo: str, branch: str) -> bool:


### PR DESCRIPTION
If a previous import failed, we want to be able to rerun it. However,
the rerun exits early right now because it sees the commit and thinks
that it's fully there.

Make it also check that the commit is not marked as partial.