### PR TITLE
coreos-ostree-importer: use latest ostree from stable repos

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -11,8 +11,7 @@ RUN dnf update -y
 RUN dnf -y install \
         fedora-messaging \
         python-requests  \
-        https://kojipkgs.fedoraproject.org/packages/ostree/2020.3/5.fc32/x86_64/ostree-2020.3-5.fc32.x86_64.rpm \
-        https://kojipkgs.fedoraproject.org/packages/ostree/2020.3/5.fc32/x86_64/ostree-libs-2020.3-5.fc32.x86_64.rpm \
+        ostree           \
         strace
 
 # Configure a umask of 0002 which will allow for the group permissions


### PR DESCRIPTION
Since that version hit bodhi stable we can go back to tracking latest.

This reverts commit 39a98ff5c9b11611340a0fc10c16b9baf262d45b.