### PR TITLE
coreos-meta-translator: add PXE rootfs image

### DIFF
--- a/coreos-meta-translator/trans.py
+++ b/coreos-meta-translator/trans.py
@@ -144,6 +144,9 @@ for f in files:
         i = input_.get("images", {}).get("live-initramfs", None)
         if i is not None:
             arch_dict["media"]["metal"]["artifacts"].setdefault("pxe", {})["initramfs"] = artifact(i)
+        i = input_.get("images", {}).get("live-rootfs", None)
+        if i is not None:
+            arch_dict["media"]["metal"]["artifacts"].setdefault("pxe", {})["rootfs"] = artifact(i)
 
         # if architectures as a whole or the individual arch is empty just push our changes
         if out.get('architectures', None) is None or out['architectures'].get(arch, None) is None:


### PR DESCRIPTION
For https://github.com/coreos/fedora-coreos-tracker/issues/390.

Example output:

```json
{
  "release": "32.20200719.dev.0",
  "stream": "testing-devel",
  "architectures": {
    "x86_64": {
      "media": {
        "metal": {
          "artifacts": {
            "raw": {
              "disk": {
                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal.x86_64.raw",
                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal.x86_64.raw.sig",
                "sha256": "d4a7e2f48a6a2437d8ed5d2f9e7d5a269cd894081169b7e2757f885c5f2ce377"
              }
            },
            "4k.raw": {
              "disk": {
                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal4k.x86_64.raw",
                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal4k.x86_64.raw.sig",
                "sha256": "a21ab5471c0402f15b587710dd3f2326a75f06ff38e2ed471951e60b9ba59501"
              }
            },
            "iso": {
              "disk": {
                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live.x86_64.iso",
                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live.x86_64.iso.sig",
                "sha256": "c2406a250c4500cf3199d33c1ef473d16731f36fa96773538c263a0e3b3c721d"
              }
            },
            "pxe": {
              "kernel": {
                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-kernel-x86_64",
                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-kernel-x86_64.sig",
                "sha256": "ca79086041c6a4471129cb48b30c72dc7854c912c20bf1db1785c5a88eca06ec"
              },
              "initramfs": {
                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-initramfs.x86_64.img",
                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-initramfs.x86_64.img.sig",
                "sha256": "71d9fdce247e8e873b4dd580c42344f286e92b318276f5aba322b53e8feabdff"
              },
              "rootfs": {
                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-rootfs.x86_64.img",
                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-rootfs.x86_64.img.sig",
                "sha256": "934d2c72e95b275a88b36a20a453464ba03c4fd858c106b692e896a00e977277"
              }
            }
          }
        },
        "qemu": {
          "artifacts": {
            "qcow2": {
              "disk": {
                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-qemu.x86_64.qcow2",
                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-qemu.x86_64.qcow2.sig",
                "sha256": "d2e907ed25da78e487c319ec748d334a032862e806cb4d70eaee2537ba3b6487"
              }
            }
          }
        }
      },
      "commit": "3326c8202c8b2c8086e9d8557b53e9da44827bbe82f72611137dc5ec16e44e6d"
    }
  }
}
```

See https://github.com/coreos/coreos-assembler/pull/1608, but can be merged independently of that PR.