### PR TITLE
coreos-koji-tagger: detonate pod if we get a koji auth error

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -12,7 +12,6 @@ RUN dnf -y install dnf-plugins-core \
                    fedora-messaging \
                    koji             \
                    python3-pyyaml   \
-                   python3-tenacity \
                    krb5-workstation
 
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by


### PR DESCRIPTION
We've tried to work around the issue in #70 several ways including
d46a3a1, a90d53d, and 286612b. Nothing seems to be working and we are
currently still at https://github.com/coreos/fedora-coreos-releng-automation/issues/70#issuecomment-600820800.
Restarting the pod seems to work well enough so let's just self destruct
if we detect this failure case. The new pod that gets created will
do a scan of the repos and pick up right where the old one left off
so this should work just fine.