### PR TITLE
coreos-koji-tagger: cherry-pick latest python3-requests-gssapi

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -12,6 +12,7 @@ RUN dnf -y install dnf-plugins-core \
                    fedora-messaging \
                    koji             \
                    python3-pyyaml   \
+                   https://kojipkgs.fedoraproject.org//packages/python-requests-gssapi/1.2.2/1.fc32/noarch/python3-requests-gssapi-1.2.2-1.fc32.noarch.rpm \
                    krb5-workstation
 
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by


### PR DESCRIPTION
We're seeing gssapi auth issues with the latest Koji update. There is an
upstream issue describing a bug in `requests-gssapi` not working well
with the Koji rollout:

https://pagure.io/koji/issue/2422

Our error is not exactly the same, though I see the same symptom
described in:

https://pagure.io/koji/issue/2422#comment-669723

where the principal used has extra appended data to it:

```
gssapi.raw.misc.GSSError: Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2529639053): Can't find client principal coreos-koji-tagger\/coreos-koji-tagger.fedoraproject.org/fedoraproject.org@FEDORAPROJECT.ORG in cache collection
```

There is a Bodhi update to the package which should fix this. Let's
cherry-pick it for now to unblock FCOS releases.