### PR TITLE
coreos-koji-tagger: remove locked python3-requests-gssapi

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -12,7 +12,6 @@ RUN dnf -y install dnf-plugins-core \
                    fedora-messaging \
                    koji             \
                    python3-pyyaml   \
-                   https://kojipkgs.fedoraproject.org//packages/python-requests-gssapi/1.2.2/1.fc32/noarch/python3-requests-gssapi-1.2.2-1.fc32.noarch.rpm \
                    krb5-workstation
 
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by


### PR DESCRIPTION
coreos-koji-tagger: remove locked python3-requests-gssapi

This was added in 82f27e3. The package is in the bodhi stable repos
now so we can go back to not pulling it directly from koji.

https://bodhi.fedoraproject.org/updates/FEDORA-2020-134329dd96
