### PR TITLE
config-bot: a few tweaks following migration to OCP4 cluster

### DIFF
--- a/config-bot/README.md
+++ b/config-bot/README.md
@@ -39,3 +39,22 @@ Then:
 ```
 ./main --config myconfig.toml
 ```
+
+### Deploying to OpenShift
+
+This app is currently deployed in the same namespace as the
+[Fedora CoreOS production
+pipeline](https://github.com/coreos/fedora-coreos-pipeline).
+
+To deploy:
+
+```
+oc new-app --file=manifest.yaml
+```
+
+Copy the generated GitHub webhook secret, and substitute it
+into the webhook URL from `oc describe bc config-bot`, then
+create a new webhook in the GitHub settings for this repo as
+described in the [OpenShift
+documentation](https://docs.openshift.com/container-platform/4.4/builds/triggering-builds-build-hooks.html#builds-using-github-webhooks_triggering-builds-build-hooks)
+using that URL.

--- a/config-bot/manifest.yaml
+++ b/config-bot/manifest.yaml
@@ -66,13 +66,13 @@ objects:
             - name: config-bot
               image: config-bot
               volumeMounts:
-                - name: github-token-mount
+                - name: github-coreosbot-token
                   mountPath: /var/run/secrets/coreos.fedoraproject.org/github-token
                   readOnly: true
           volumes:
-          - name: github-token-mount
+          - name: github-coreosbot-token
             secret:
-              secretName: config-bot-github-token
+              secretName: github-coreosbot-token
       triggers:
         - type: ConfigChange
         - type: ImageChange


### PR DESCRIPTION
```
commit 60e4489d8c53c4abbcb25595a0697220ad76be6d
Date:   Wed Aug 26 15:40:42 2020 -0400

    config-bot/manifest: use same GitHub coreosbot secret as pipeline

    Since we're deployed in the same namespace anyway, might as well reuse
    the same secret.

commit bdfde294b4758bf88ef093f13982414dd6159e58
Date:   Wed Aug 26 15:41:11 2020 -0400

    config-bot/README: add details about deploying to OpenShift

    Pretty straight-forward, but just to have it written down somewhere.
```