### PR TITLE
config-bot: propagate files from testing-devel to rawhide

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -32,6 +32,7 @@ target-refs = [
     # for now we inherit from testing-devel; see discussions starting from
     # https://github.com/coreos/fedora-coreos-config/pull/180#issuecomment-534697400
     'next-devel',
+    'rawhide',
 ]
 skip-files = [
     'manifest.yaml',


### PR DESCRIPTION
We'll try for now to keep using testing-devel as the source config ref
for rawhide builds. We can adapt in the future if it gets too tricky.