### PR TITLE
broadcast-fedmsg: add build_metadata key to build.state.change msgs

### DIFF
--- a/scripts/broadcast-fedmsg.py
+++ b/scripts/broadcast-fedmsg.py
@@ -67,6 +67,7 @@ def msg_build_state_change(args):
         "stream": args.stream,
         "state": args.state,
         "build_dir": args.build_dir,
+        "build_metadata": f"{args.build_dir}/meta.json",
     }
     if args.result:
         body['result'] = args.result


### PR DESCRIPTION
Be nice to consumers and not have them construct the URL to `meta.json`.
Then the API is something like "you can look at the build metadata in
`build_metadata` and you can download files mentioned in there relative
to `build_dir`".