### PR TITLE
config-bot: propagate files from testing-devel to branched

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -32,6 +32,7 @@ target-refs = [
     # for now we inherit from testing-devel; see discussions starting from
     # https://github.com/coreos/fedora-coreos-config/pull/180#issuecomment-534697400
     'next-devel',
+    'branched',
     'rawhide',
 ]
 skip-files = [


### PR DESCRIPTION
Let's just stay with the theme of `testing-devel` being the source ref
for now.