### PR TITLE
scripts/download-overrides.py: fix regression from archless overrides

### DIFF
--- a/scripts/download-overrides.py
+++ b/scripts/download-overrides.py
@@ -24,9 +24,8 @@ def get_rpminfo(string: str) -> str:
     return rpminfo
 
 def is_override_lockfile(filename: str) -> bool:
-    return ((filename.startswith(f'manifest-lock.overrides') or
-             filename.startswith(f'manifest-lock.overrides.{arch}'))
-            and filename[-4:] in ['json', 'yaml'])
+    return (filename == "manifest-lock.overrides.yaml" or
+            filename == f'manifest-lock.overrides.{arch}.yaml')
 
 def assert_epochs_match(overrides_epoch: int, rpmfile_epoch: str):
     # normalize the input into a string


### PR DESCRIPTION
The `startswith` check for the archless overrides also matches the
archful ones, which means we were downloading all the RPMs for all
arches.

Really, it's silly to do these loose checks just to support the JSON
version when we don't have any plans to support those (even though cosa
today does support them). Just tighten this all up to check for the
specific filenames we expect.