### PR TITLE
config-bot: don't sync image.yaml

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -38,6 +38,7 @@ target-refs = [
 skip-files = [
     'manifest.yaml',
     'manifest-lock.*',
+    'image.yaml',
 ]
 trigger.mode = 'periodic'
 trigger.period = '15m'


### PR DESCRIPTION
We now have `image-base.yaml` and `image.yaml`, where the latter is only
meant for a specific stream, while the former is shared. For more
information, see:

https://github.com/coreos/fedora-coreos-tracker/issues/292#issuecomment-806099932
https://github.com/coreos/coreos-assembler/pull/2096
https://github.com/coreos/fedora-coreos-config/pull/908