### PR TITLE
config-bot/manifest.yaml: use separate token for config-bot

### DIFF
--- a/config-bot/README.md
+++ b/config-bot/README.md
@@ -46,6 +46,10 @@ This app is currently deployed in the same namespace as the
 [Fedora CoreOS production
 pipeline](https://github.com/coreos/fedora-coreos-pipeline).
 
+However, it expects to use a different GitHub token
+(`github-coreosbot-token-config-bot`) which only needs
+`repo:public_repo` scope.
+
 To deploy:
 
 ```

--- a/config-bot/manifest.yaml
+++ b/config-bot/manifest.yaml
@@ -72,7 +72,7 @@ objects:
           volumes:
           - name: github-coreosbot-token
             secret:
-              secretName: github-coreosbot-token
+              secretName: github-coreosbot-token-config-bot
       triggers:
         - type: ConfigChange
         - type: ImageChange


### PR DESCRIPTION
All config-bot needs is cloning and pushing. Let's use a separate token
for that from the more powerful github-coreosbot-token.