### PR TITLE
coreos-koji-tagger: watch/tag override lockfile from the rawhide branch

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -44,7 +44,7 @@ COREOS_KOJI_USER = 'coreosbot'
 
 # XXX: should be in config file
 DEFAULT_GITHUB_REPO_FULLNAME = 'coreos/fedora-coreos-config'
-DEFAULT_GITHUB_REPO_BRANCHES = 'refs/heads/testing-devel refs/heads/next-devel'
+DEFAULT_GITHUB_REPO_BRANCHES = 'refs/heads/testing-devel refs/heads/next-devel refs/heads/rawhide'
 
 ARCHES = ['x86_64', 'aarch64', 'ppc64le', 's390x']
 


### PR DESCRIPTION
We want to be able to pin packages in rawhide to keep things green while
we work with upstreams to get fixes applied.