### PR TITLE
coreos-koji-tagger: add monitoring of our production branches

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -44,7 +44,7 @@ COREOS_KOJI_USER = 'coreosbot'
 
 # XXX: should be in config file
 DEFAULT_GITHUB_REPO_FULLNAME = 'coreos/fedora-coreos-config'
-DEFAULT_GITHUB_REPO_BRANCHES = 'refs/heads/testing-devel refs/heads/next-devel refs/heads/rawhide  refs/heads/branched'
+DEFAULT_GITHUB_REPO_BRANCHES = 'testing-devel next-devel rawhide branched'
 
 ARCHES = ['x86_64', 'aarch64', 'ppc64le', 's390x']
 
@@ -269,7 +269,7 @@ class Consumer(object):
 
         # do an initial run on startup in case we're out of sync
         for branch in self.github_repo_branches:
-            self.process_lockfiles(branch[len("refs/heads/"):])
+            self.process_lockfiles(branch)
 
 
     def __call__(self, message: fedora_messaging.api.Message):
@@ -289,7 +289,7 @@ class Consumer(object):
             logger.info(f'Skipping message from unrelated repo: {repo}')
             return
 
-        if (branch not in self.github_repo_branches):
+        if (branch[len("refs/heads/"):] not in self.github_repo_branches):
             logger.info(f'Skipping message from unrelated branch: {branch}')
             return
 

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -44,7 +44,7 @@ COREOS_KOJI_USER = 'coreosbot'
 
 # XXX: should be in config file
 DEFAULT_GITHUB_REPO_FULLNAME = 'coreos/fedora-coreos-config'
-DEFAULT_GITHUB_REPO_BRANCHES = 'testing-devel next-devel rawhide branched'
+DEFAULT_GITHUB_REPO_BRANCHES = 'next next-devel testing testing-devel stable rawhide branched'
 
 ARCHES = ['x86_64', 'aarch64', 'ppc64le', 's390x']
 


### PR DESCRIPTION
For the first time ever we decided to fast-track a package directly
to testing/next rather than have it go through testing-devel first.
This meant the tagger didn't pick up and have the package signed/tagged.

Let's monitor our production branches too.
