### PR TITLE
coreos-koji-tagger: bump signing timeout to 30 mins

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -423,8 +423,8 @@ class Consumer(object):
                 # Before running distrepo let's wait for all rpms to
                 # pass through signing and make it into the target tag
                 #
-                # If not done in ten minutes then just timeout (60*10s = 10 minutes)
-                for x in range(0, 60):
+                # If not done in thirty minutes then just timeout (60*3*10s = 30 minutes)
+                for x in range(0, 60*3):
                     currentbuildids = self.get_tagged_buildids(self.target_tag)
                     difference = desiredbuildids - currentbuildids
                     if difference:


### PR DESCRIPTION
We just hit the case where a lot of packages needed to be tagged, and
there was genuine progress being made but the timer ran out. So then I
had to manually run `koji dist-repo`.

Let's just bump the timeout to 30 minutes to catch this.

A smarter method we could follow-up with on this would be to check if
the difference is getting smaller and reset the timeout if so.