### PR TITLE
coreos-ostree-importer: support OCI archives

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf update -y
 RUN dnf -y install \
         fedora-messaging \
         python-requests  \
-        ostree           \
+        rpm-ostree       \
         strace
 
 # Configure a umask of 0002 which will allow for the group permissions


### PR DESCRIPTION
FCOS rawhide is now producing archives in the new OCI format. We have to
use `rpm-ostree ex-container import` to extract those.

Closes: #145