### PR TITLE
coreos-ostree-importer: add skopeo to package set

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -8,10 +8,12 @@ ENV PYTHONUNBUFFERED=true
 RUN dnf update -y
 
 # Install needed rpms
+# skopeo is needed for `rpm-ostree ex-container import`
 RUN dnf -y install \
         fedora-messaging \
         python-requests  \
         rpm-ostree       \
+        skopeo           \
         strace
 
 # Configure a umask of 0002 which will allow for the group permissions


### PR DESCRIPTION
It's needed for `rpm-ostree ex-container import`. Else
you'll get an error like:

```
Importing ostree-unverified-image:oci-archive:/tmp/tmpi4g6huq7/ostree-archive:
Fetching manifest: Failed to exec skopeo: No such file or directory
```