### PR TITLE
config-bot: add README instructions to create secret token and drop BuildConfig GitHub trigger

### DIFF
--- a/config-bot/README.md
+++ b/config-bot/README.md
@@ -64,10 +64,3 @@ To deploy:
 ```
 oc new-app --file=manifest.yaml
 ```
-
-Copy the generated GitHub webhook secret, and substitute it
-into the webhook URL from `oc describe bc config-bot`, then
-create a new webhook in the GitHub settings for this repo as
-described in the [OpenShift
-documentation](https://docs.openshift.com/container-platform/4.4/builds/triggering-builds-build-hooks.html#builds-using-github-webhooks_triggering-builds-build-hooks)
-using that URL.

--- a/config-bot/README.md
+++ b/config-bot/README.md
@@ -48,7 +48,16 @@ pipeline](https://github.com/coreos/fedora-coreos-pipeline).
 
 However, it expects to use a different GitHub token
 (`github-coreosbot-token-config-bot`) which only needs
-`repo:public_repo` scope.
+`repo:public_repo` scope. You can find this token in
+BitWarden.
+
+To create the secret:
+
+```
+$ read token
+<token>
+$ oc create secret generic github-coreosbot-token-config-bot --from-literal=token=$token
+```
 
 To deploy:
 

--- a/config-bot/manifest.yaml
+++ b/config-bot/manifest.yaml
@@ -14,10 +14,6 @@ parameters:
   - description: Git branch/tag reference for Dockerfile
     name: REPO_REF
     value: main
-  - description: GitHub webhook secret
-    name: GITHUB_WEBHOOK_SECRET
-    from: '[A-Z0-9]{32}'
-    generate: expression
 objects:
   - kind: ImageStream
     apiVersion: v1
@@ -33,9 +29,6 @@ objects:
     spec:
       triggers:
       - type: ConfigChange
-      - type: GitHub
-        github:
-          secret: ${GITHUB_WEBHOOK_SECRET}
       source:
         type: Git
         git:


### PR DESCRIPTION
See individual commits.