### PR TITLE
scripts/promote-config: add `LOCAL` for local hacking

### DIFF
--- a/scripts/promote-config.sh
+++ b/scripts/promote-config.sh
@@ -21,8 +21,12 @@ main() {
     local src_branch=$1; shift
     local fetch_head head
 
-    git fetch https://github.com/coreos/fedora-coreos-config "${src_branch}"
-    fetch_head=$(git rev-parse FETCH_HEAD)
+    if [ -z "${LOCAL:-}" ]; then
+        git fetch https://github.com/coreos/fedora-coreos-config "${src_branch}"
+        fetch_head=$(git rev-parse FETCH_HEAD)
+    else
+        fetch_head=$(git rev-parse "${src_branch}")
+    fi
     head=$(git rev-parse HEAD)
 
     # take all the changes from the src branch


### PR DESCRIPTION
If e.g. you're hacking on `testing-devel` locally and then want to test
`next-devel` with those changes as if they were propagated by the bot,
you can use this.