### PR TITLE
Revert "config-bot: drop BuildConfig GitHub trigger"

### DIFF
--- a/config-bot/README.md
+++ b/config-bot/README.md
@@ -64,3 +64,10 @@ To deploy:
 ```
 oc new-app --file=manifest.yaml
 ```
+
+Copy the generated GitHub webhook secret, and substitute it
+into the webhook URL from `oc describe bc config-bot`, then
+create a new webhook in the GitHub settings for this repo as
+described in the [OpenShift
+documentation](https://docs.openshift.com/container-platform/4.4/builds/triggering-builds-build-hooks.html#builds-using-github-webhooks_triggering-builds-build-hooks)
+using that URL.

--- a/config-bot/manifest.yaml
+++ b/config-bot/manifest.yaml
@@ -14,6 +14,10 @@ parameters:
   - description: Git branch/tag reference for Dockerfile
     name: REPO_REF
     value: main
+  - description: GitHub webhook secret
+    name: GITHUB_WEBHOOK_SECRET
+    from: '[A-Z0-9]{32}'
+    generate: expression
 objects:
   - kind: ImageStream
     apiVersion: v1
@@ -29,6 +33,9 @@ objects:
     spec:
       triggers:
       - type: ConfigChange
+      - type: GitHub
+        github:
+          secret: ${GITHUB_WEBHOOK_SECRET}
       source:
         type: Git
         git:


### PR DESCRIPTION
This reverts commit a36ed742946f79371d7ea6c9f98d273280af6b37.

This should work again now that the API server is public:
https://pagure.io/fedora-infrastructure/issue/10521