### PR TITLE
Updates for tagger and importer

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:36
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # periods with no newline get printed immediately to the screen

--- a/coreos-koji-tagger/README.md
+++ b/coreos-koji-tagger/README.md
@@ -20,14 +20,14 @@ executing:
 
 The application will then be running in Fedora OpenShift instances:
 
-- [PROD](https://os.fedoraproject.org/console/project/coreos-koji-tagger/)
-- [STAGE](https://os.stg.fedoraproject.org/console/project/coreos-koji-tagger/)
+- [PROD](https://console-openshift-console.apps.ocp.fedoraproject.org/k8s/cluster/projects/coreos-koji-tagger)
+- [STAGE](https://console-openshift-console.apps.ocp.stg.fedoraproject.org/k8s/cluster/projects/coreos-koji-tagger)
 
 If you have appropriate permissions you'll be able to view them in the
 OpenShift web interface.
 
 To limit executing playbooks against `prod` or `staging` you can use
-`-l os_masters[0]` or `-l os_masters_stg[0]`.
+`-l os_control` or `-l os_control_stg`.
 
 To take down the application completely:
 
@@ -46,7 +46,7 @@ there are two inputs which you can control:
 
 In order to update the source code you need to push to the repo/branch
 currently being monitored by the
-[the buildconfig](https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/openshift-apps/coreos-koji-tagger/templates/buildconfig.yml).
+[the buildconfig](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/coreos-koji-tagger/templates/buildconfig.yml).
 for the staging environment. This will most likely be the
 `fedora-infra-staging` branch of this git repo.
 
@@ -55,7 +55,7 @@ in stage you need to push code to the repo/branch currently being monitored
 by the staging coreos-koji-tagger. This involves changing the manifest file(s)
 and pushing to the git repo. To see the branch/repo currently being
 monitored you can see that in the
-[deploymentconfig](https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/openshift-apps/coreos-koji-tagger/templates/deploymentconfig.yml).
+[deploymentconfig](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/coreos-koji-tagger/templates/deploymentconfig.yml).
 
 You'll need to either push to the target branch/repo or you'll need to
 update the deploymentconfig to point to another one that you control. The

--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:36
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # output immediately comes to the console

--- a/coreos-ostree-importer/README.md
+++ b/coreos-ostree-importer/README.md
@@ -21,14 +21,14 @@ executing:
 
 The application will then be running in Fedora OpenShift instances:
 
-- [PROD](https://os.fedoraproject.org/console/project/coreos-ostree-importer/)
-- [STAGE](https://os.stg.fedoraproject.org/console/project/coreos-ostree-importer/)
+- [PROD](https://console-openshift-console.apps.ocp.fedoraproject.org/k8s/cluster/projects/coreos-ostree-importer)
+- [STAGE](https://console-openshift-console.apps.ocp.stg.fedoraproject.org/k8s/cluster/projects/coreos-ostree-importer)
 
 If you have appropriate permissions you'll be able to view them in the
 OpenShift web interface.
 
 To limit executing playbooks against `prod` or `staging` you can use
-`-l os_masters[0]` or `-l os_masters_stg[0]`.
+`-l os_control` or `-l os_control_stg`.
 
 To take down the application completely:
 


### PR DESCRIPTION
```
commit 358af5fd09c810c6ecfd9895055b4bd1d5250fd2
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Apr 21 16:55:02 2022 -0400

    coreos-koji-tagger: move to F36 and migrate to new cluster
    
    We migrated to the new OpenShift v4 cluster in Fedora's
    infrastructure and rebased to Fedora 36 in the process.
    
    Also updated a few links from cgit to pagure that should have
    been updated previously.

commit be05f3bb0bce50b445ed0daacd368e0c3693401a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Apr 21 16:53:30 2022 -0400

    coreos-ostree-importer: move to F36 and migrate to new cluster
    
    We migrated to the new OpenShift v4 cluster in Fedora's
    infrastructure and rebased to Fedora 36 in the process.

```
