### PR TITLE
Revert "config-bot: temporarily skip syncing platforms.yaml"

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -39,9 +39,6 @@ skip-files = [
     'manifest.yaml',
     'manifest-lock.*',
     'image.yaml',
-    # Temporary exclusion to allow 'next' to diverge
-    # https://github.com/coreos/fedora-coreos-tracker/issues/567#issuecomment-1150275044
-    'platforms.yaml',
 ]
 trigger.mode = 'periodic'
 trigger.period = '15m'


### PR DESCRIPTION
Once `platforms.yaml` promotes to `testing-devel`, we will no longer need it to diverge across our development branches.

Reverts #153.