### PR TITLE
config-bot/manifest.yaml: remove unnecessary fields

### DIFF
--- a/config-bot/manifest.yaml
+++ b/config-bot/manifest.yaml
@@ -1,12 +1,7 @@
 apiVersion: v1
 kind: Template
-labels:
-  app: config-bot
 metadata:
   name: fedora-coreos-config-bot-template
-  annotations:
-    description: |-
-      Fedora CoreOS Config Bot
 parameters:
   - description: Git source URI for Dockerfile
     name: REPO_URL


### PR DESCRIPTION
Those fields are only useful if instantiating the template itself, which
we're not doing here.

This is similar to what was done in:
https://github.com/coreos/fedora-coreos-pipeline/pull/582

My main motivation though is to get a commit in so that we can test that
https://pagure.io/fedora-infrastructure/issue/10603 is resolved.