### PR TITLE
importer: Use `ostree container`, not `rpm-ostree ex-container`

### DIFF
--- a/coreos-ostree-importer/coreos_ostree_importer.py
+++ b/coreos-ostree-importer/coreos_ostree_importer.py
@@ -285,7 +285,7 @@ def unpack_ostree_from_url(url: str, tmpdir: str, sha256sum: str):
         raise Exception("Checksums do not match: " f"{sha256sum} != {calcuatedsum}")
 
     runcmd(["ostree", "init", "--repo", tmpdir, "--mode=bare-user"])
-    runcmd(["rpm-ostree", "ex-container", "import", "--repo", tmpdir,
+    runcmd(["ostree", "container", "unencapsulate", "--repo", tmpdir,
             f"ostree-unverified-image:oci-archive:{filepath}"])
 
 


### PR DESCRIPTION
The latter is deprecated now.  I noticed this in the code motion from
https://github.com/coreos/fedora-coreos-releng-automation/pull/158/commits/9ed720ed10caf6c56a6a507a32813a5ab54a6faf