### PR TITLE
fedora-ostree-pruner: drop hardcoding of test mode; limit to compose repo

### DIFF
--- a/fedora-ostree-pruner/fedora-ostree-pruner
+++ b/fedora-ostree-pruner/fedora-ostree-pruner
@@ -32,7 +32,7 @@ FEDORA_EOL_LIST = [27, 28, 29, 30, 31, 32, 33, 34]
 
 ATOMIC_HOST_ARCHES = ['x86_64', 'aarch64', 'ppc64le']
 SILVERBLUE_ARCHES = ['x86_64', 'aarch64', 'ppc64le']  # Applies to Kinoite
-FEDORA_COREOS_ARCHES = ['x86_64', 'aarch64']
+FEDORA_COREOS_ARCHES = ['x86_64', 'aarch64', 'ppc64le', 's390x']
 
 # https://github.com/coreos/fedora-coreos-tracker/blob/main/stream-tooling.md#introduction
 FEDORA_COREOS_PRODUCTION_STREAMS = ['next', 'testing', 'stable']

--- a/fedora-ostree-pruner/fedora-ostree-pruner
+++ b/fedora-ostree-pruner/fedora-ostree-pruner
@@ -237,11 +237,6 @@ def main():
                         help="Loop forever, run once a week.", action='store_true')
     args = parser.parse_args()
 
-    # set args.test = True for now. Once we have proved
-    # everything out in prod and the logs look good we'll
-    # delete this code.
-    args.test = True
-
     # on startup let's print out the config that was generated
     logger.info('The configured policy is: \n%s' %
                 pprint.pformat(PROD_REF_POLICIES, indent=8))
@@ -255,7 +250,8 @@ def main():
 
     # Prune the compose and the prod repo based on policy
     prune_compose_repo(args.test)
-    prune_prod_repo(args.test)
+    # wait to prune the prod repo til after the 2022 holidays
+    #prune_prod_repo(args.test)
 
     # If we were asked to run in a loop, then run once a week on
     # Saturday.
@@ -267,7 +263,8 @@ def main():
             day = days[datetime.date.today().weekday()]
             if day == 'Saturday':
                 prune_compose_repo(args.test)
-                prune_prod_repo(args.test)
+                # wait to prune the prod repo til after the 2022 holidays
+                #prune_prod_repo(args.test)
             else:
                 logger.info(f"Today is {day}. Sleeping...")
 


### PR DESCRIPTION
```
commit 5690b6bc17e1decfd30d0061217b62400e049fae
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Dec 14 10:16:39 2022 -0500

    fedora-ostree-pruner: drop hardcoding of test mode; limit to compose repo
    
    We're in a position right now where we need to recover some space but
    Kevin Fenzi is out on a much deserved break. Let's make this script
    start taking real action by unsetting `args.test = True`, but let's
    be conservative and only operate on the compose repo for now until
    Kevin gets back.
    
    In the most recent test this got us 1.2T in space back:
    
    ```
    Total objects: 10768149
    Would delete: 7437430 objects, freeing 1.2 TB
    ```

commit 575b0b1af63bb25f50d21418d30787043ce87208
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Dec 14 10:14:53 2022 -0500

    fedora-ostree-pruner: add ppc64le and s390x fedora-coreos arches
    
    We now have s390x and will soon have ppc64le in the prod repo for
    Fedora CoreOS.

```
