### PR TITLE
scripts/promote-config: don't promote snoozes in denylist

### DIFF
--- a/scripts/promote-config.sh
+++ b/scripts/promote-config.sh
@@ -36,6 +36,10 @@ main() {
     # except for manifest.yaml
     git checkout -- manifest.yaml
 
+    # also strip out the snoozes in the denylist because we don't want
+    # changes in the executed tests over time for production streams
+    sed -E -i 's/^(\s+)(snooze:\s+.*)/\1# \2 (disabled on promotion)/' kola-denylist.yaml
+
     git add -A
     if git diff --quiet --staged --exit-code; then
         echo "nothing to promote! exiting..."


### PR DESCRIPTION
For our production streams we don't want tests that weren't originally run for the original promotion to start running later (either on an ad-hoc build or for `stable` a few weeks later). Let's strip out the snooze lines when we do the promotion.