### PR TITLE
fedora-ostree-pruner: skip over aliased refs

### DIFF
--- a/fedora-ostree-pruner/fedora-ostree-pruner
+++ b/fedora-ostree-pruner/fedora-ostree-pruner
@@ -190,11 +190,6 @@ def prune_prod_repo(test=False):
                                f' repo {OSTREEPRODREPO}: {ref}')
             continue
 
-    # Get the list of aliased refs in the repo
-    cmd = ['ostree', 'refs', '--repo', OSTREEPRODREPO, '--alias']
-    cp = runcmd(cmd, capture_output=True)
-    prod_ref_aliases = [line.split(' ')[0] for line in cp.stdout.decode('utf-8').splitlines()]
-
     # prune each branch in the policy with specified value
     for ref,policy in PROD_REF_POLICIES.items():
 
@@ -207,7 +202,8 @@ def prune_prod_repo(test=False):
                         ' Policy is to keep all commits.')
             continue
 
-        if ref in prod_ref_aliases:
+        # Detect if the ref is an alias (they are symlinks) and skip if so.
+        if os.path.islink(f'{OSTREEPRODREPO}/refs/heads/{ref}'):
             logger.info(f'Skipping operations on alias {ref} in repo {OSTREEPRODREPO}.')
             continue
 

--- a/fedora-ostree-pruner/fedora-ostree-pruner
+++ b/fedora-ostree-pruner/fedora-ostree-pruner
@@ -190,6 +190,11 @@ def prune_prod_repo(test=False):
                                f' repo {OSTREEPRODREPO}: {ref}')
             continue
 
+    # Get the list of aliased refs in the repo
+    cmd = ['ostree', 'refs', '--repo', OSTREEPRODREPO, '--alias']
+    cp = runcmd(cmd, capture_output=True)
+    prod_ref_aliases = [line.split(' ')[0] for line in cp.stdout.decode('utf-8').splitlines()]
+
     # prune each branch in the policy with specified value
     for ref,policy in PROD_REF_POLICIES.items():
 
@@ -200,6 +205,10 @@ def prune_prod_repo(test=False):
         if policy is None:
             logger.info(f'Skipping ref {ref} in repo {OSTREEPRODREPO}.'
                         'Policy is to keep all commits.')
+            continue
+
+        if ref in prod_ref_aliases:
+            logger.info(f'Skipping operations on alias {ref} in repo {OSTREEPRODREPO}.')
             continue
 
         if policy == 'delete':

--- a/fedora-ostree-pruner/fedora-ostree-pruner
+++ b/fedora-ostree-pruner/fedora-ostree-pruner
@@ -204,7 +204,7 @@ def prune_prod_repo(test=False):
 
         if policy is None:
             logger.info(f'Skipping ref {ref} in repo {OSTREEPRODREPO}.'
-                        'Policy is to keep all commits.')
+                        ' Policy is to keep all commits.')
             continue
 
         if ref in prod_ref_aliases:


### PR DESCRIPTION
Let's not operate on aliased refs. Rather than require the person
who comes up with the configuration to understand what is an alias
and what isn't let's just do the right thing in the code.

We've seen an issue (we think) where a ref gets deleted and then
running `ostree summary -u` fails and we think it has to do with
operating on aliased refs. Let's find out.
