### PR TITLE
use dumb-init for the coreos-ostree-importer and fedora-ostree-pruner

### DIFF
--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -10,6 +10,7 @@ RUN dnf update -y
 # Install needed rpms
 # skopeo is needed for `rpm-ostree ex-container import`
 RUN dnf -y install \
+        dumb-init        \
         fedora-messaging \
         python-requests  \
         rpm-ostree       \
@@ -38,5 +39,5 @@ ADD fedora-messaging-config.toml /etc/fedora-messaging/config.toml
 # Copy in the wrapper that starts the importer
 ADD coreos-ostree-importer-wrapper /usr/local/bin/
 
-# Call the wrapper
-CMD ["/usr/local/bin/coreos-ostree-importer-wrapper"]
+# Use dumb-init (reaps defunct processes) to call the importer
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/coreos-ostree-importer-wrapper"]

--- a/fedora-ostree-pruner/Dockerfile
+++ b/fedora-ostree-pruner/Dockerfile
@@ -7,8 +7,8 @@ ENV PYTHONUNBUFFERED=true
 # Get any latest updates since last container spin
 RUN dnf update -y
 
-# Install ostree
-RUN dnf -y install ostree
+# Install ostree/dumb-init
+RUN dnf -y install ostree dumb-init
 
 # Configure a umask of 0002 which will allow for the group permissions
 # to include write for newly created files. We need this because we'd
@@ -25,5 +25,5 @@ RUN echo 'umask 0002' > /etc/profile.d/umask-for-openshift.sh
 # Put the file into typical place for execuatables
 ADD fedora-ostree-pruner /usr/local/bin/
 
-# Call the pruner and tell it to loop
-CMD ["/usr/local/bin/fedora-ostree-pruner", "--loop"]
+# Use dumb-init (reaps defunct processes) to call the pruner
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/fedora-ostree-pruner", "--loop"]


### PR DESCRIPTION
Sometimes we use the pods for the importer and pruner to inspect and fix issues with the OSTree repos since it's the most efficient way for us to gain read/write access to the repos. Recently I was restoring some data that was lost in a recent prune [1] and the `ostree pull` operation I was running failed with an obscure error message:

```
error: Commit 1eb251bced7652f2f486c15447a7bf00238ef0ea172b4f214d2684ecfbeb2c40:
GPG: GPG: Failed to import key: GPGME: System error w/o errno
```

It turns out the many gpg processes that get forked during a pull operation to verify the signatures for the commits don't get cleaned up:

```
1000720+   11737       1  0 14:59 pts/4    00:00:00 [gpg] <defunct>
1000720+   11740       1  0 14:59 pts/4    00:00:00 [gpg] <defunct>
1000720+   11743       1  0 14:59 pts/4    00:00:00 [gpg] <defunct>
1000720+   11746       1  0 14:59 pts/4    00:00:00 [gpg] <defunct>
...
```

Let's use `dumb-init` to reap these defunct processes.

[1] https://github.com/fedora-silverblue/issue-tracker/issues/405#issuecomment-1407794147