### PR TITLE
cci.jenkinsfile: Modify jenkinsfile to stop installing python3-toml

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -4,6 +4,6 @@ cosaPod(runAsUser: 0) {
     checkout scm
     // required by config-bot (XXX: should have a deps.txt file for each
     // subproject or something)
-    shwrap("dnf install -y python3-aiohttp python3-toml")
+    shwrap("dnf install -y python3-aiohttp")
     shwrap("./run-pylint")
 }


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-releng-automation/issues/164