### PR TITLE
scripts/promote-config: strip warn: out of denylist on promotion

### DIFF
--- a/scripts/promote-config.sh
+++ b/scripts/promote-config.sh
@@ -36,9 +36,9 @@ main() {
     # except for manifest.yaml
     git checkout -- manifest.yaml
 
-    # also strip out the snoozes in the denylist because we don't want
-    # changes in the executed tests over time for production streams
-    sed -E -i 's/^(\s+)(snooze:\s+.*)/\1# \2 (disabled on promotion)/' kola-denylist.yaml
+    # also strip out the snoozes and warns in the denylist because we don't
+    # want changes in the executed tests over time for production streams
+    sed -E -i 's/^(\s+)((snooze:|warn:)\s+.*)/\1# \2 (disabled on promotion)/'
 
     git add -A
     if git diff --quiet --staged --exit-code; then


### PR DESCRIPTION
warn: true was added in https://github.com/coreos/coreos-assembler/pull/3539 and can be used to make test failures non-fatal in the pipeline. Let's strip those from the denylist too on promotion.