### PR TITLE
Revert "config-bot: also sync new `experimental` branch"

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -34,7 +34,6 @@ target-refs = [
     'next-devel',
     'branched',
     'rawhide',
-    'experimental',
 ]
 # Files to not clobber in target refs.
 # Ref-specific skip files can be specified in `.coreos.skip-files`.


### PR DESCRIPTION
This reverts commit cad1c9303e4f51ae4e781467d6acca206726fcca.

As mentioned in https://github.com/coreos/fedora-coreos-tracker/issues/1446#issuecomment-1693823642 we don't really need it anymore.