### PR TITLE
coreos-koji-tagger: tag packages from rawhide builds into pool

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -38,8 +38,8 @@ RUN sed -i 's/INFO/WARNING/' /work/my_config.toml
 # Set the format for the log messages
 RUN sed -i 's/format =.*$/format = "%(asctime)s %(levelname)s %(name)s - %(message)s"/' /work/my_config.toml
 
-# We only care about org.fedoraproject.prod.github.push messages
-RUN sed -i 's/^routing_keys.*$/routing_keys = ["org.fedoraproject.prod.github.push"]/' /work/my_config.toml
+# We only care about these two topics
+RUN sed -i 's/^routing_keys.*$/routing_keys = ["org.fedoraproject.prod.github.push", "org.fedoraproject.prod.coreos.stream.release"]/' /work/my_config.toml
 
 # Add coreos_koji_tagger to the container
 ADD coreos_koji_tagger.py /work/

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -311,13 +311,6 @@ class Consumer(object):
             logger.error('No commit id in message!')
             return
 
-        # Check the login. If it's bad then a koji.AuthError exception will get thrown.
-        # and we'll exit because catch_exceptions_and_continue() will raise it.
-        # This is the only way we've come up with to deal with the problem in
-        # https://github.com/coreos/fedora-coreos-releng-automation/issues/70
-        if self.keytab_file:
-            self.koji_client.getLoggedInUser()
-
         self.process_git_lockfiles(commit)
 
     @catch_exceptions_and_continue
@@ -353,6 +346,13 @@ class Consumer(object):
         self.tag_rpms(desiredrpms)
 
     def tag_rpms(self, desiredrpms):
+
+        # Check the login. If it's bad then a koji.AuthError exception will get thrown.
+        # and we'll exit because catch_exceptions_and_continue() will raise it.
+        # This is the only way we've come up with to deal with the problem in
+        # https://github.com/coreos/fedora-coreos-releng-automation/issues/70
+        if self.keytab_file:
+            self.koji_client.getLoggedInUser()
 
         # NOMENCLATURE:
         # 


### PR DESCRIPTION
For the Bodhi testing work, when testing a rawhide update, we want to
test against a known working rawhide build. To do this, we want to base
our build on the last working rawhide combination. We do this by reusing
the generated lockfile from that build and the git commit of the config
repo.

But for this to work, we need to make sure that we have access to all
the RPMs in that build.

This patch teaches coreos-koji-tagger to listen to the
`coreos.stream.release` fedmsg that the release job emits to know
when a new rawhide build is available; it then downloads the generated
lockfiles and tags in the packages.

Closes: #181