### PR TITLE
coreos-koji-tagger/Dockerfile: move to Fedora 39

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:39
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # periods with no newline get printed immediately to the screen


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-tracker/issues/1490