### PR TITLE
scripts/promote-config: fix git submodule handling

### DIFF
--- a/scripts/promote-config.sh
+++ b/scripts/promote-config.sh
@@ -30,7 +30,8 @@ main() {
     head=$(git rev-parse HEAD)
 
     # take all the changes from the src branch, including any submodules
-    git reset --hard "${fetch_head}" --recurse-submodules
+    git reset --hard "${fetch_head}"
+    git submodule update --init
     git reset "${head}"
 
     # except for manifest.yaml


### PR DESCRIPTION
The `--recurse-submodules` option to `git reset` only works if there are already submodules to recurse into. In the case where we're promoting from one branch which has a submodule to one which doesn't, this will not cause a git submodule directory to be created. Instead, we need to explicitly initialize potential new submodules.

We also need to handle the case where the submodule did exist but it was bumped by the promotion and so we need to update it.

Calling `git submodule update --init` handles both cases.