### PR TITLE
fedora-ostree-pruner: add 42 to the stable list

### DIFF
--- a/fedora-ostree-pruner/fedora-ostree-pruner
+++ b/fedora-ostree-pruner/fedora-ostree-pruner
@@ -27,7 +27,7 @@ logger = logging.getLogger('fedora-ostree-pruner')
 OSTREECOMPOSEREPO = '/mnt/koji/compose/ostree/repo'
 OSTREEPRODREPO = '/mnt/koji/ostree/repo'
 
-FEDORA_STABLE_LIST = [40, 41]
+FEDORA_STABLE_LIST = [40, 41, 42]
 FEDORA_EOL_LIST = [27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
 
 ATOMIC_HOST_ARCHES = ['x86_64', 'aarch64', 'ppc64le']


### PR DESCRIPTION
We've branched for 42 so those refs are in the repo now.