### PR TITLE
coreos-koji-tagger: log when no ref in msg

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -303,6 +303,10 @@ class Consumer(object):
     def process_github_push_message(self, message: fedora_messaging.api.Message):
         # Grab the raw message body and the status from that
         msg = message.body
+        if 'ref' not in msg:
+            logger.error('No ref in message!')
+            logger.error(msg)
+            return
         branch = msg['ref']
         repo   = msg['repository']['full_name']
 


### PR DESCRIPTION
Been seeing a lot of `KeyError: 'ref'` lately so let's add some debugging to try to figure it out.