### PR TITLE
coreos-koji-tagger: Update for schema changes

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -49,7 +49,7 @@ DEFAULT_GITHUB_REPO_BRANCHES = 'next next-devel testing testing-devel stable raw
 ARCHES = ['x86_64', 'aarch64', 'ppc64le', 's390x']
 
 # We are processing the org.fedoraproject.prod.github.push topic
-# https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.github.push&delta=100000
+# https://apps.fedoraproject.org/datagrepper/v2/search?topic=org.fedoraproject.prod.github.push&contains=fedora-coreos-config&delta=100000
 EXAMPLE_GITHUB_PUSH_MESSAGE_BODY = json.loads("""
 {
     "forced": false, 

--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -302,7 +302,7 @@ class Consumer(object):
 
     def process_github_push_message(self, message: fedora_messaging.api.Message):
         # Grab the raw message body and the status from that
-        msg = message.body
+        msg = message.body["body"]
         if 'ref' not in msg:
             logger.error('No ref in message!')
             logger.error(msg)


### PR DESCRIPTION
The schema of the message changed recently as explained to me:

> Oh yes the format has changed indeed, you'll find the content of the
> webhook in the "body" subkey, so message.body["body"]. The format change
> is annoying indeed, but it gives you access to the webhook headers, and
> lets the schema find out who is the agent of the change (for FMN).
