### PR TITLE
scripts/promote-config: don't promote image.yaml

### DIFF
--- a/scripts/promote-config.sh
+++ b/scripts/promote-config.sh
@@ -34,8 +34,8 @@ main() {
     git submodule update --init
     git reset "${head}"
 
-    # except for manifest.yaml
-    git checkout -- manifest.yaml
+    # except for manifest.yaml and image.yaml
+    git checkout -- manifest.yaml image.yaml
 
     # also strip out the snoozes and warns in the denylist because we don't
     # want changes in the executed tests over time for production streams


### PR DESCRIPTION
With the OCI change, we now have stream-specific bits in `image.yaml` that shouldn't be shared across promotion; the `container-imgref` field contains the stream name.

Ideally we should template that field instead because overall, we should still continue promotion of `image.yaml` and keep all stream identity bits scoped to `manifest.yaml`. Once templatized, long-term once the OCI migration is over, that field could live in `image-base.yaml` proper.

But for now, let's make sure we don't do the wrong thing.