### PR TITLE
coreos-koji-tagger: bump signing timeout to 90m

### DIFF
--- a/coreos-koji-tagger/coreos_koji_tagger.py
+++ b/coreos-koji-tagger/coreos_koji_tagger.py
@@ -490,15 +490,15 @@ class Consumer(object):
                 # Before running distrepo let's wait for all rpms to
                 # pass through signing and make it into the target tag
                 #
-                # If not done in thirty minutes then just timeout (60*3*10s = 30 minutes)
-                for x in range(0, 60*3):
+                # If not done in ninety minutes then just timeout # (90*2*30s = 90 minutes)
+                for x in range(0, 90*2):
                     currentbuildids = self.get_tagged_buildids(self.target_tag)
                     difference = desiredbuildids - currentbuildids
                     if difference:
                         logger.info('Waiting on builds to be signed')
                         logger.info('Remaining builds: %s' %
                                         [buildsinfo[x].nvr for x in difference])
-                        time.sleep(10)
+                        time.sleep(30)
                         continue
                     break
                 # If all the builds didn't make it into the target


### PR DESCRIPTION
Sometimes builds get stuck in the signer and the signer itself has a timeout at 60 minutes. So if we get in this situation we could have to wait 60 minutes and then also for the queue to get processed down to our position in the queue. Let's try 90 minutes as a timeout to see if we can get less runs that give up before getting to the distrepo step.