### PR TITLE
CoreOS tools: Update to Fedora 42

### DIFF
--- a/config-bot/Dockerfile
+++ b/config-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 
 RUN dnf -y install git python3-aiohttp && dnf clean all
 

--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # periods with no newline get printed immediately to the screen

--- a/coreos-ostree-importer/Dockerfile
+++ b/coreos-ostree-importer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # output immediately comes to the console

--- a/fedora-ostree-pruner/Dockerfile
+++ b/fedora-ostree-pruner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # output immediately comes to the console


### PR DESCRIPTION
Ref:https://github.com/coreos/fedora-coreos-tracker/issues/1851

Bump the following Dockerfiles to fedora:42

```
config-bot
coreos-koji-tagger
coreos-ostree-importer
fedora-ostree-pruner
```