### PR TITLE
coreos-koji-tagger/Dockerfile: install util-linux

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -8,11 +8,13 @@ ENV PYTHONUNBUFFERED=true
 RUN dnf update -y
 
 # Install necessary (fedmsg/koji/yaml) libraries
+# Include util-linux (upgrade from util-linux-core) for /usr/bin/uuidgen
 RUN dnf -y install dnf-plugins-core \
                    fedora-messaging \
                    koji             \
                    python3-pyyaml   \
-                   krb5-workstation
+                   krb5-workstation \
+                   util-linux
 
 # Grab the kerberos/koji configuration (i.e. /usr/bin/stg-koji) by
 # installing the fedora-packager rpm. We don't need the deps because


### PR DESCRIPTION
There is a new util-linux-core package that is the baseline in the F42 containerfile, but uuidgen (used in the Dockerfile for the build) didn't make the cut for the -core package so let's install the full util-linux.