### PR TITLE
coreos-koji-tagger/Dockerfile: create the my_config.toml file

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /work
 WORKDIR /work
 
 # Set the Application Name
-RUN sed -i 's|Example Application|CoreOS Koji Tagger: https://github.com/coreos/fedora-coreos-releng-automation/tree/main/coreos-koji-tagger |' /work/my_config.toml
+RUN sed -i 's|Example Application|CoreOS Koji Tagger: https://github.com/coreos/fedora-coreos-releng-automation/tree/main/coreos-koji-tagger |' /etc/fedora-messaging/fedora.toml > /work/my_config.toml
 
 # Lower log levels to WARNING level
 RUN sed -i 's/INFO/WARNING/' /work/my_config.toml


### PR DESCRIPTION
The line that was deleted in the last commit actually did two things. It rand a find/replace and also created the file. Let's do the creation of the file in the new first sed command.

Fixes 16e368f