### PR TITLE
coreos-koji-tagger/Dockerfile: fix another typo

### DIFF
--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /work
 WORKDIR /work
 
 # Set the Application Name
-RUN sed -i 's|Example Application|CoreOS Koji Tagger: https://github.com/coreos/fedora-coreos-releng-automation/tree/main/coreos-koji-tagger |' /etc/fedora-messaging/fedora.toml > /work/my_config.toml
+RUN sed -e 's|Example Application|CoreOS Koji Tagger: https://github.com/coreos/fedora-coreos-releng-automation/tree/main/coreos-koji-tagger |' /etc/fedora-messaging/fedora.toml > /work/my_config.toml
 
 # Lower log levels to WARNING level
 RUN sed -i 's/INFO/WARNING/' /work/my_config.toml


### PR DESCRIPTION
In the previous fix I forgot to make this a -e sed and not -i for inplace edits, so the changes would go to stdout and populate my_config.toml.

Fixes da44a99