### PR TITLE
config-bot: update apiVersion as required by OpenShift

### DIFF
--- a/config-bot/manifest.yaml
+++ b/config-bot/manifest.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: fedora-coreos-config-bot-template


### PR DESCRIPTION
Newer OpenShift will no longer process templates without being more verbose with the specification.