### PR TITLE
config-bot: don't clobber build-args.conf

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -41,6 +41,7 @@ skip-files = [
     'manifest.yaml',
     'manifest-lock.*',
     'image.yaml',
+    'build-args.conf',
 ]
 trigger.mode = 'periodic'
 trigger.period = '15m'


### PR DESCRIPTION
In the container-native path, `build-args.conf` becomes the new `manifest.yaml`. I.e. stream-specific arguments go in there. So they must not be synced across branches.