### PR TITLE
config-bot: don't clobber renovate.json

### DIFF
--- a/config-bot/config.toml
+++ b/config-bot/config.toml
@@ -42,6 +42,7 @@ skip-files = [
     'manifest-lock.*',
     'image.yaml',
     'build-args.conf',
+    'renovate.json',
 ]
 trigger.mode = 'periodic'
 trigger.period = '15m'


### PR DESCRIPTION
Renovate uses the config from the repository's default branch. See [1] for more details.
It's a follow-up of [2]

[1] https://docs.renovatebot.com/configuration-options/
[2] https://github.com/coreos/fedora-coreos-config/pull/3613