### PR TITLE
CoreOS tools: update to Fedora 44

### DIFF
--- a/config-bot/Dockerfile
+++ b/config-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
 RUN dnf -y install git python3-aiohttp && dnf clean all
 

--- a/coreos-koji-tagger/Dockerfile
+++ b/coreos-koji-tagger/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # periods with no newline get printed immediately to the screen

--- a/fedora-ostree-pruner/Dockerfile
+++ b/fedora-ostree-pruner/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
 # set PYTHONUNBUFFERED env var to non-empty string so that our
 # output immediately comes to the console


### PR DESCRIPTION
Update the following tools to Fedora 44:
- config-bot
- coreos-koji-tagger
- fedora-ostree-pruner

xref: https://github.com/coreos/fedora-coreos-tracker/issues/2055