### PR TITLE
scripts: add make-update-graph-ostree-repo-tarball.sh

### DIFF
--- a/scripts/make-update-graph-ostree-repo-tarball.sh
+++ b/scripts/make-update-graph-ostree-repo-tarball.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# make-update-graph-ostree-repo-tarball.sh
+#
+# Collects OSTree commits for all unique target versions in the
+# Fedora CoreOS update graph and packages them into a tarball.
+#
+# Usage:
+#   ./make-update-graph-ostree-repo-tarball.sh <architecture> <stream>
+#
+# Examples:
+#   ./make-update-graph-ostree-repo-tarball.sh x86_64 stable
+#
+#   OR 
+#
+#   STREAMS='stable testing next'
+#   ARCHES='aarch64 ppc64le s390x x86_64'
+#   mkdir -p fedora && pushd fedora
+#   for stream in $STREAMS; do
+#       for arch in $ARCHES; do
+#           ./make-update-graph-ostree-repo-tarball.sh ${arch} ${stream}
+#           rm -rf ./repo/
+#       done
+#   done
+#
+#
+# Then upload with something like:
+#   aws s3 sync --no-overwrite ./ s3://fcos-upgrade-test-fixtures/
+
+
+set -euo pipefail
+
+# --- Validate inputs ---
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <architecture> <stream>"
+    echo "  architecture: e.g. x86_64, aarch64"
+    echo "  stream:       e.g. stable, testing, next"
+    exit 1
+fi
+
+ARCH="$1"
+STREAM="$2"
+
+# --- Check required tools ---
+
+for cmd in curl jq ostree tar; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: required command '$cmd' not found in PATH"
+        exit 1
+    fi
+done
+
+# --- Fetch the update graph ---
+
+GRAPH_URL="https://updates.coreos.fedoraproject.org/v1/graph?basearch=${ARCH}&stream=${STREAM}&oci=false"
+
+echo "Fetching update graph from: ${GRAPH_URL}"
+GRAPH_JSON=$(curl -sSf "$GRAPH_URL")
+
+# --- Extract unique target versions (>= 32) from graph edges ---
+#
+# The graph has "nodes" (array of objects with .version) and "edges"
+# (array of [from_index, to_index] pairs). We collect unique
+# destination indices, map them to versions, and filter to major
+# version >= 32.
+
+TARGET_VERSIONS=$(echo "$GRAPH_JSON" | jq -r '
+    .nodes as $nodes |
+    [.edges[][1]] | unique | .[] |
+    $nodes[.].version
+' | while IFS= read -r version; do
+    major="${version%%.*}"
+    if [[ "$major" -ge 32 ]] 2>/dev/null; then
+        echo "$version"
+    fi
+done)
+
+if [[ -z "$TARGET_VERSIONS" ]]; then
+    echo "Error: no target versions with major version >= 32 found in update graph"
+    exit 1
+fi
+
+echo ""
+echo "Target versions in update graph (major version >= 32):"
+echo "$TARGET_VERSIONS" | while IFS= read -r v; do
+    echo "  $v"
+done
+
+# --- Fetch releases.json ---
+
+RELEASES_URL="https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/releases.json"
+
+echo ""
+echo "Fetching releases.json from: ${RELEASES_URL}"
+RELEASES_JSON=$(curl -sSf "$RELEASES_URL")
+
+# --- Cross-reference versions with releases.json to find commits ---
+#
+# releases.json has:
+#   .releases[] | { .version, .commits[] | { .architecture, .checksum } }
+#
+# We look up each target version and find the commit checksum for the
+# requested architecture. We store the results in an associative array
+# mapping version -> commit hash.
+
+declare -A VERSION_TO_COMMIT=()
+
+echo ""
+echo "Resolving commits for each target version:"
+while IFS= read -r version; do
+    commit=$(echo "$RELEASES_JSON" | jq -r \
+        --arg version "$version" \
+        --arg arch "$ARCH" \
+        '.releases[] | select(.version == $version) |
+         .commits[] | select(.architecture == $arch) |
+         .checksum')
+
+    if [[ -z "$commit" ]]; then
+        echo "  Warning: no commit found for version ${version} / arch ${ARCH}, skipping"
+        continue
+    fi
+
+    echo "  ${version} -> ${commit}"
+    VERSION_TO_COMMIT["$version"]="$commit"
+done <<< "$TARGET_VERSIONS"
+
+if [[ ${#VERSION_TO_COMMIT[@]} -eq 0 ]]; then
+    echo "Error: no commits resolved for any target version"
+    exit 1
+fi
+
+echo ""
+echo "Total commits to pull: ${#VERSION_TO_COMMIT[@]}"
+
+# --- Sort versions in descending order ---
+#
+# We walk from newest to oldest, creating a cumulative tarball each
+# time the Fedora major version changes. Each tarball includes all
+# commits pulled so far.
+
+SORTED_VERSIONS=$(for v in "${!VERSION_TO_COMMIT[@]}"; do echo "$v"; done | sort -rV)
+
+# --- Initialize empty ostree repository ---
+
+if [[ -d ./repo ]]; then
+    echo "Error: ./repo directory already exists. Remove it first."
+    exit 1
+fi
+
+echo ""
+echo "Initializing ostree repository..."
+mkdir ./repo
+ostree --repo=./repo init --mode=archive
+ostree --repo=./repo remote add fedora \
+    https://kojipkgs.fedoraproject.org/ostree/repo/ \
+    --set=gpgkeypath=/etc/pki/rpm-gpg/
+
+# --- Lightweight pull of commit metadata for history of the branch ---
+
+# The --commit-metadata-only keeps it lightweight. The --mirror means
+# the fedora/${ARCH}/coreos/${STREAM} ref will get created in the local repo.
+echo "Pulling lightweight commit history for branch fedora/${ARCH}/coreos/${STREAM}"
+ostree --repo=./repo pull --mirror --commit-metadata-only --depth=-1 "fedora:fedora/${ARCH}/coreos/${STREAM}"
+
+# --- Pull commits and create tarballs at major version boundaries ---
+
+echo ""
+echo "Pulling commits and creating tarballs..."
+
+CURRENT_MAJOR=""
+declare -a TARBALLS=()
+
+while IFS= read -r version; do
+    major="${version%%.*}"
+
+    # If the major version changed and we have a previous major to
+    # snapshot, create a tarball for it before moving on.
+    if [[ -n "$CURRENT_MAJOR" && "$major" != "$CURRENT_MAJOR" ]]; then
+        TARBALL="ostree-repo-${STREAM}-${ARCH}-starting-f${CURRENT_MAJOR}.tar"
+        echo ""
+        echo "Major version boundary: creating ${TARBALL}"
+        tar -C ./repo/ -cf "$TARBALL" ./
+        TARBALLS+=("$TARBALL")
+    fi
+
+    CURRENT_MAJOR="$major"
+    commit="${VERSION_TO_COMMIT[$version]}"
+    echo "  Pulling ${version} (${commit})..."
+    ostree --repo=./repo pull fedora "$commit"
+done <<< "$SORTED_VERSIONS"
+
+# Create the final tarball for the last (oldest) major version
+TARBALL="ostree-repo-${STREAM}-${ARCH}-starting-f${CURRENT_MAJOR}.tar"
+echo ""
+echo "Final major version: creating ${TARBALL}"
+tar -C ./repo/ -cf "$TARBALL" ./
+TARBALLS+=("$TARBALL")
+
+# --- Summary ---
+
+echo ""
+echo "Done. Created ${#TARBALLS[@]} tarballs:"
+for t in "${TARBALLS[@]}"; do
+    echo "  $t"
+done
+echo ""
+echo "Note: the ./repo directory still exists. You may want to remove it with:"
+echo "  rm -rf ./repo"


### PR DESCRIPTION
This script will consult the update graph and the release index for a given stream/architecture of Fedora CoreOS and build a tarball for every major version of Fedora. This is useful for streamlining extended upgrade tests.

```
$ ./make-update-graph-ostree-repo-tarball.sh testing s390x testing
Fetching update graph from: https://updates.coreos.fedoraproject.org/v1/graph?basearch=s390x&stream=testing&oci=false

Target versions in update graph (major version >= 32):
  36.20221030.2.3
  37.20230322.2.0
  38.20231014.2.0
  39.20240104.2.0
  39.20240407.2.0
  40.20240701.2.0
  40.20241019.2.0
  41.20250331.2.0
  42.20250901.2.0
  42.20250929.2.0

Fetching releases.json from: https://builds.coreos.fedoraproject.org/prod/streams/testing/releases.json

Resolving commits for each target version:
  36.20221030.2.3 -> ea6f9472633c14bb888f90e4d8c1031b3e1ab30f1b4c8240d4b645bd6394c2c9
  37.20230322.2.0 -> 738e52e570c7c5a15acfde16072cd518ce9b2ae96810b5bbac87cb443ad116e9
  38.20231014.2.0 -> 5e7615b55b3d417199244a8e1652367a29bf736b33105371712279d840a88195
  39.20240104.2.0 -> 5b4a49d8a917c18b1a7cbf4879643b66df98abca6350b7a1a828211597ba2871
  39.20240407.2.0 -> 1f930fd5c6e0ef7a793558df702d8f694abf3ac8d539a039b1f31c523ff49fbb
  40.20240701.2.0 -> 1701286c22f660a762d54c406d2f98eba8a8a1b576d720c43c4b9f58760452b5
  40.20241019.2.0 -> 304fdb382350efa7cf693f81a416ff252c7256bbb9b46490a72d6b99ab94bac9
  41.20250331.2.0 -> 5181352a8c2b2e9a1356d92913c518765c09043552db9e8bea8d87757c87a1da
  42.20250901.2.0 -> cf263739cf42b9555daab6062f1acea833de6012286387d8bdcb51d01bd4d7af
  42.20250929.2.0 -> 22d2b4e7013a29b803bb97ba5c2b128ae72c43db34f6b4b7e37451f9581fb744

Total commits to pull: 10

Initializing ostree repository...
Pulling lightweight commit history for branch fedora/s390x/coreos/testing
...
...
...

Done. Created 5 tarballs:
  ostree-repo-testing-s390x-starting-f42.tar
  ostree-repo-testing-s390x-starting-f41.tar
  ostree-repo-testing-s390x-starting-f40.tar
  ostree-repo-testing-s390x-starting-f39.tar
  ostree-repo-testing-s390x-starting-f38.tar
  ostree-repo-testing-s390x-starting-f37.tar
  ostree-repo-testing-s390x-starting-f36.tar
```

Assisted-by: <anthropic/claude-opus-4.6>